### PR TITLE
Clean up if device intialization fails.

### DIFF
--- a/linux/device.go
+++ b/linux/device.go
@@ -28,17 +28,20 @@ func NewDeviceWithNameAndHandler(name string, handler ble.NotifyHandler, opts ..
 		return nil, errors.Wrap(err, "can't create hci")
 	}
 	if err = dev.Init(); err != nil {
+		dev.Close()
 		return nil, errors.Wrap(err, "can't init hci")
 	}
 
 	srv, err := gatt.NewServerWithNameAndHandler(name, handler)
 	if err != nil {
+		dev.Close()
 		return nil, errors.Wrap(err, "can't create server")
 	}
 
 	// mtu := ble.DefaultMTU
 	mtu := ble.MaxMTU // TODO: get this from user using Option.
 	if mtu > ble.MaxMTU {
+		dev.Close()
 		return nil, errors.Wrapf(err, "maximum ATT_MTU is %d", ble.MaxMTU)
 	}
 

--- a/linux/hci/hci.go
+++ b/linux/hci/hci.go
@@ -293,7 +293,10 @@ func (h *HCI) sktLoop() {
 
 func (h *HCI) close(err error) error {
 	h.err = err
-	return h.skt.Close()
+	if h.skt != nil {
+		return h.skt.Close()
+	}
+	return err
 }
 
 func (h *HCI) handlePkt(b []byte) error {


### PR DESCRIPTION
Make sure the HCI socket is closed if device initialization fails.
Without this, the library leaks file handles on errors.
