### PR TITLE
Fix race condition on disconnect

### DIFF
--- a/linux/hci/hci.go
+++ b/linux/hci/hci.go
@@ -514,7 +514,7 @@ func (h *HCI) handleDisconnectionComplete(b []byte) error {
 	// When a connection disconnects, all the sent packets and weren't acked yet
 	// will be recycled. [Vol2, Part E 4.1.1]
 	//
-	// must be done wwith the pool locked to avoid race conditions where
+	// must be done with the pool locked to avoid race conditions where
 	// writePDU is in progress and does a Get from the pool after this completes,
 	// leaking a buffer from the main pool.
 	c.txBuffer.LockPool()

--- a/linux/hci/hci.go
+++ b/linux/hci/hci.go
@@ -513,7 +513,13 @@ func (h *HCI) handleDisconnectionComplete(b []byte) error {
 	}
 	// When a connection disconnects, all the sent packets and weren't acked yet
 	// will be recycled. [Vol2, Part E 4.1.1]
+	//
+	// must be done wwith the pool locked to avoid race conditions where
+	// writePDU is in progress and does a Get from the pool after this completes,
+	// leaking a buffer from the main pool.
+	c.txBuffer.LockPool()
 	c.txBuffer.PutAll()
+	c.txBuffer.UnlockPool()
 	return nil
 }
 


### PR DESCRIPTION
The library can write new data to a connection while it is being disconnected, and the buffers used for that data  are leaked from the packet pool forever.  This can happen invisibly even if the application isn't sending data, e.g. when a Connection Parameter Update Request comes in and the library automatically generates a response.

The fix checks for a closed connection before writing data, and both the check and the final packet pool update are done while holding the packet pool lock.  This guarantees the final pool drain for the closed connection happens after any writes on the connection are complete.
