### PR TITLE
Emergency timeout for failed HCI sends

### DIFF
--- a/linux/hci/hci.go
+++ b/linux/hci/hci.go
@@ -295,7 +295,11 @@ func (h *HCI) sktLoop() {
 	for {
 		n, err := h.skt.Read(b)
 		if n == 0 || err != nil {
-			h.err = fmt.Errorf("skt: %s", err)
+			if err == io.EOF {
+				h.err = err //callers depend on detecting io.EOF, don't wrap it.
+			} else {
+				h.err = fmt.Errorf("skt: %s", err)
+			}
 			return
 		}
 		p := make([]byte, n)

--- a/linux/hci/hci.go
+++ b/linux/hci/hci.go
@@ -259,20 +259,34 @@ func (h *HCI) send(c Command) ([]byte, error) {
 		h.close(fmt.Errorf("hci: failed to send whole cmd pkt to hci socket"))
 	}
 
+	var ret []byte
+	var err error
+
 	// emergency timeout to prevent calls from locking up if the HCI
 	// interface doesn't respond.  Responsed here should normally be fast
 	// a timeout indicates a major problem with HCI.
 	timeout := time.NewTimer(10 * time.Second)
 	select {
 	case <-timeout.C:
-		return nil, fmt.Errorf("hci: no response to command, hci connection failed")
+		err = fmt.Errorf("hci: no response to command, hci connection failed")
+		ret = nil
 	case <-h.done:
-		timeout.Stop()
-		return nil, h.err
+		err = h.err
+		ret = nil
 	case b := <-p.done:
-		timeout.Stop()
-		return b, nil
+		err = nil
+		ret = b
 	}
+	timeout.Stop()
+
+	// clear sent table when done, we sometimes get command complete or
+	// command status messages with no matching send, which can attempt to
+	// access stale packets in sent and fail or lock up.
+	h.muSent.Lock()
+	delete(h.sent, c.OpCode())
+	h.muSent.Unlock()
+
+	return ret, err
 }
 
 func (h *HCI) sktLoop() {

--- a/linux/hci/socket/socket.go
+++ b/linux/hci/socket/socket.go
@@ -119,14 +119,21 @@ func open(fd, id int) (*Socket, error) {
 }
 
 func (s *Socket) Read(p []byte) (int, error) {
+	s.rmu.Lock()
+	n, err := unix.Read(s.fd, p)
+	s.rmu.Unlock()
+	// Close always sends a dummy command to wake up Read
+	// bad things happen to the HCI state machines if they receive
+	// a reply from that command, so make sure no data is returned
+	// on a closed socket.
+	//
+	// note that if Write and Close are called concurrently it's
+	// indeterminate which replies get through.
 	select {
 	case <-s.closed:
 		return 0, io.EOF
 	default:
 	}
-	s.rmu.Lock()
-	defer s.rmu.Unlock()
-	n, err := unix.Read(s.fd, p)
 	return n, errors.Wrap(err, "can't read hci socket")
 }
 
@@ -139,7 +146,7 @@ func (s *Socket) Write(p []byte) (int, error) {
 
 func (s *Socket) Close() error {
 	close(s.closed)
-	s.Write([]byte{0x01, 0x09, 0x10, 0x00})
+	s.Write([]byte{0x01, 0x09, 0x10, 0x00}) // no-op command to wake up the Read call if it's blocked
 	s.rmu.Lock()
 	defer s.rmu.Unlock()
 	return errors.Wrap(unix.Close(s.fd), "can't close hci socket")


### PR DESCRIPTION
We've seen a stack trace where go-ble locked up because ble/linux/hci.(*HCI).send waits forever on a select for data to return.
This probably indicates some kind of problem deeper in the Bluetooth stack, but it would be good if the library didn't hang in these situations.

Now includes some additional cleanup to the socket Read path to handle some weird lockups on send and device stop, which were revealed in testing for the send failure.

