### PR TITLE
fix: unsafe handling of key generation could lead to a race condition

### DIFF
--- a/linux/hci/smp/manager.go
+++ b/linux/hci/smp/manager.go
@@ -100,13 +100,12 @@ func (m *manager) Handle(in []byte) error {
 }
 
 func (m *manager) Pair(authData ble.AuthData, to time.Duration) error {
-	keys, err := GenerateKeys()
-	if err != nil {
-		fmt.Println("error generating secure keys:", err)
+
+	if m.t.pairing.state != Init {
+		return fmt.Errorf("Pairing already in progress")
 	}
 
 	//todo: can this be made less bad??
-	m.pairing.scECDHKeys = keys
 	m.t.pairing = m.pairing
 	m.t.pairing.authData = authData
 
@@ -119,7 +118,7 @@ func (m *manager) Pair(authData ble.AuthData, to time.Duration) error {
 		m.t.pairing.request.OobFlag = byte(hci.OobPreset)
 	}
 
-	err = m.t.StartPairing(to)
+	err := m.t.StartPairing(to)
 	if err != nil {
 		return err
 	}

--- a/linux/hci/smp/transport.go
+++ b/linux/hci/smp/transport.go
@@ -90,9 +90,15 @@ func (t *transport) sendPairingRequest() error {
 }
 
 func (t *transport) sendPublicKey() error {
-	kp := t.pairing.scECDHKeys
+	if t.pairing.scECDHKeys == nil {
+		keys, err := GenerateKeys()
+		if err != nil {
+			fmt.Println("error generating secure keys:", err)
+		}
+		t.pairing.scECDHKeys = keys
+	}
 
-	k := MarshalPublicKeyXY(kp.public)
+	k := MarshalPublicKeyXY(t.pairing.scECDHKeys.public)
 
 	t.pairing.state = WaitPublicKey
 	out := append([]byte{pairingPublicKey}, k...)


### PR DESCRIPTION
The way keys are currently generated is unsafe in the case of slave security requests.
This will lead to a `sendPairingRequest` call before the keys are done being generated (in a separate thread), causing a dereference of a null pointer (`scECDHKeys`).
This commit fixes the issue, where keys are generated in the `t.pairing.scECDHKeys` function. 