### PR TITLE
More logging

### DIFF
--- a/linux/att/client.go
+++ b/linux/att/client.go
@@ -622,6 +622,7 @@ func (c *Client) Loop() {
 		}
 
 		n, err := c.l2c.Read(c.rxBuf)
+
 		if err != nil {
 			logger.Info("client", "read error", err.Error())
 			// We don't expect any error from the bearer (L2CAP ACL-U)
@@ -632,6 +633,7 @@ func (c *Client) Loop() {
 
 		b := make([]byte, n)
 		copy(b, c.rxBuf)
+		logger.Debug("client", "data in", fmt.Sprintf("% X", b))
 
 		//all incoming requests are even numbered
 		//which means the last bit should be 0

--- a/linux/hci/conn.go
+++ b/linux/hci/conn.go
@@ -361,7 +361,7 @@ func (c *Conn) recombine() error {
 	}
 
 	p := pdu(pkt.data())
-
+	logger.Debug("recombine", "pdu in:", fmt.Sprintf("% X", pkt.data()))
 	// Currently, check for LE-U only. For channels that we don't recognizes,
 	// re-combine them anyway, and discard them later when we dispatch the PDU
 	// according to CID.

--- a/linux/hci/hci.go
+++ b/linux/hci/hci.go
@@ -768,16 +768,17 @@ func (h *HCI) cleanupConnectionHandle(ch uint16) error {
 
 	h.muConns.Lock()
 	defer h.muConns.Unlock()
-	//logger.Debug("hci", "[BLE] cleanupConnHan: looking for %04X\n", ch)
+	logger.Debug("hci", "cleanupConnHan: looking for", fmt.Sprintf("%04X", ch))
 	c, found := h.conns[ch]
 	if !found {
-		return fmt.Errorf("disconnecting an invalid handle %04X", ch)
+		return nil
+		//return fmt.Errorf("disconnecting an invalid handle %04X", ch)
 	}
 
-	//logger.Debug("hci", "[BLE] clenupConnHan %04X: found device with address %s\n", ch, c.RemoteAddr().String())
+	logger.Debug("hci", "", fmt.Sprintf("clenupConnHan %04X: found device with address %s\n", ch, c.RemoteAddr().String()))
 
 	delete(h.conns, ch)
-	//logger.Debug("[BLE] cleanupConnHan %04X: close c.chInPkt\n", ch)
+	logger.Debug("hci", "[BLE] cleanupConnHan close c.chInPkt", fmt.Sprintf("%04X", ch))
 	close(c.chInPkt)
 
 	if !h.isOpen() && c.param.Role() == roleSlave {
@@ -792,7 +793,7 @@ func (h *HCI) cleanupConnectionHandle(ch uint16) error {
 		h.params.RUnlock()
 	} else {
 		// remote peripheral disconnected
-		//logger.Debug("[BLE] cleanupConnHan %04X: close c.chDone\n", ch)
+		logger.Debug("hci", "cleanupConnHan close c.chDone", fmt.Sprint("%04X", ch))
 		close(c.chDone)
 	}
 	// When a connection disconnects, all the sent packets and weren't acked yet
@@ -811,7 +812,7 @@ func (h *HCI) handleDisconnectionComplete(b []byte) error {
 	e := evt.DisconnectionComplete(b)
 	ch := e.ConnectionHandle()
 	logger.Debug("hci", "[BLE] disconnect complete for handle", fmt.Sprintf("%04x", ch))
-	return nil //h.cleanupConnectionHandle(ch)
+	return h.cleanupConnectionHandle(ch)
 }
 
 func (h *HCI) handleEncryptionChange(b []byte) error {

--- a/linux/hci/hci.go
+++ b/linux/hci/hci.go
@@ -400,7 +400,7 @@ func (h *HCI) sktProcessLoop() {
 			// Some bluetooth devices may append vendor specific packets at the last,
 			// in this case, simply ignore them.
 			if strings.HasPrefix(err.Error(), "unsupported vendor packet:") {
-				_ = logger.Error("skt: %v", err)
+				_ = logger.Error("hci", "skt: ", err)
 			} else {
 				h.err = fmt.Errorf("skt handle error: %v", err)
 				return
@@ -484,7 +484,7 @@ func (h *HCI) handleACL(b []byte) error {
 	if c, ok := h.conns[handle]; ok {
 		c.chInPkt <- b
 	} else {
-		_ = logger.Warn("invalid connection handle on ACL packet", "handle", handle)
+		_ = logger.Warn("invalid connection handle on ACL packet", "handle:", handle)
 	}
 
 	return nil
@@ -721,7 +721,7 @@ func (h *HCI) handleLEConnectionComplete(b []byte) error {
 	h.muConns.Lock()
 	pa := e.PeerAddress()
 	addr := pa[:]
-	logger.Debug("[BLE] connection complete for %04X: addr: %s, lecc evt: %s\n", e.ConnectionHandle(), hex.EncodeToString(addr), hex.EncodeToString(b))
+	logger.Debug("hci", fmt.Sprintf("[BLE] connection complete for %04X: addr: %s, lecc evt: %s\n", e.ConnectionHandle(), hex.EncodeToString(addr), hex.EncodeToString(b)))
 	h.conns[e.ConnectionHandle()] = c
 	h.muConns.Unlock()
 
@@ -768,16 +768,16 @@ func (h *HCI) cleanupConnectionHandle(ch uint16) error {
 
 	h.muConns.Lock()
 	defer h.muConns.Unlock()
-	logger.Debug("[BLE] cleanupConnHan: looking for %04X\n", ch)
+	//logger.Debug("hci", "[BLE] cleanupConnHan: looking for %04X\n", ch)
 	c, found := h.conns[ch]
 	if !found {
 		return fmt.Errorf("disconnecting an invalid handle %04X", ch)
 	}
 
-	logger.Debug("[BLE] clenupConnHan %04X: found device with address %s\n", ch, c.RemoteAddr().String())
+	//logger.Debug("hci", "[BLE] clenupConnHan %04X: found device with address %s\n", ch, c.RemoteAddr().String())
 
 	delete(h.conns, ch)
-	logger.Debug("[BLE] cleanupConnHan %04X: close c.chInPkt\n", ch)
+	//logger.Debug("[BLE] cleanupConnHan %04X: close c.chInPkt\n", ch)
 	close(c.chInPkt)
 
 	if !h.isOpen() && c.param.Role() == roleSlave {
@@ -792,7 +792,7 @@ func (h *HCI) cleanupConnectionHandle(ch uint16) error {
 		h.params.RUnlock()
 	} else {
 		// remote peripheral disconnected
-		logger.Debug("[BLE] cleanupConnHan %04X: close c.chDone\n", ch)
+		//logger.Debug("[BLE] cleanupConnHan %04X: close c.chDone\n", ch)
 		close(c.chDone)
 	}
 	// When a connection disconnects, all the sent packets and weren't acked yet
@@ -810,7 +810,7 @@ func (h *HCI) cleanupConnectionHandle(ch uint16) error {
 func (h *HCI) handleDisconnectionComplete(b []byte) error {
 	e := evt.DisconnectionComplete(b)
 	ch := e.ConnectionHandle()
-	logger.Debug("[BLE] disconnect complete for handle %04X\n", ch)
+	//logger.Debug("[BLE] disconnect complete for handle %04X\n", ch)
 	return nil //h.cleanupConnectionHandle(ch)
 }
 

--- a/linux/hci/hci.go
+++ b/linux/hci/hci.go
@@ -810,7 +810,7 @@ func (h *HCI) cleanupConnectionHandle(ch uint16) error {
 func (h *HCI) handleDisconnectionComplete(b []byte) error {
 	e := evt.DisconnectionComplete(b)
 	ch := e.ConnectionHandle()
-	//logger.Debug("[BLE] disconnect complete for handle %04X\n", ch)
+	logger.Debug("hci", "[BLE] disconnect complete for handle", fmt.Sprintf("%04x", ch))
 	return nil //h.cleanupConnectionHandle(ch)
 }
 

--- a/linux/hci/log.go
+++ b/linux/hci/log.go
@@ -1,7 +1,7 @@
 package hci
 
 import (
-	"github.com/mgutz/logxi/v1"
+	"github.com/rigado/ble"
 )
 
-var logger = log.New("hci")
+var logger = ble.Logger


### PR DESCRIPTION
* More debug logging
* Make HCI level logging use the same logger as the rest of the project
* On disconnect complete calls connection handle cleanup to ensure if this happens async, it cleans up correctly.