### PR TITLE
fix: in case of trying to allocate an empty pool, return an error

### DIFF
--- a/linux/hci/buffer.go
+++ b/linux/hci/buffer.go
@@ -2,6 +2,7 @@ package hci
 
 import (
 	"bytes"
+	"fmt"
 	"sync"
 )
 
@@ -15,12 +16,15 @@ type Pool struct {
 }
 
 // NewPool ...
-func NewPool(sz int, cnt int) *Pool {
+func NewPool(sz int, cnt int) (*Pool, error) {
+	if cnt == 0 {
+		return nil, fmt.Errorf("invalid buffer size")
+	}
 	ch := make(chan *bytes.Buffer, cnt)
 	for len(ch) < cnt {
 		ch <- bytes.NewBuffer(make([]byte, sz))
 	}
-	return &Pool{sz: sz, cnt: cnt, ch: ch}
+	return &Pool{sz: sz, cnt: cnt, ch: ch}, nil
 }
 
 // Client ...

--- a/linux/hci/hci.go
+++ b/linux/hci/hci.go
@@ -173,7 +173,10 @@ func (h *HCI) Init() error {
 
 	// Pre-allocate buffers with additional head room for lower layer headers.
 	// HCI header (1 Byte) + ACL Data Header (4 bytes) + L2CAP PDU (or fragment)
-	h.pool = NewPool(1+4+h.bufSize, h.bufCnt-1)
+	h.pool, err = NewPool(1+4+h.bufSize, h.bufCnt-1)
+	if err != nil {
+		return err
+	}
 	h.Send(&p.advParams, nil)
 	h.Send(&p.scanParams, nil)
 	return nil


### PR DESCRIPTION
While trying to run an application using this stack on a raspberry pi, I found a bug which occurs if none of the commands in `hci.init()` succeed. In this case, `h.bufCnt` and `.bufSize` never get initialized (they stay zero) and a panic follows:
```
# ./mcumgr-arm32-bgrid --conntype ble --connstring ctlr_name=hci0,peer_id=c1:d3:e4:bd:2b:5d -t 60 -r 3 image list
no response to command
pending commands:
cmd: c03 pkt: 01030c00
hci: no response to command, hci connection failed
chCmdBufs get timeout
chCmdBufs get timeout
chCmdBufs get timeout
chCmdBufs get timeout
chCmdBufs get timeout
chCmdBufs get timeout
chCmdBufs get timeout
panic: makechan: size out of range

goroutine 1 [running]:
github.com/rigado/ble/linux/hci.NewPool(0x5, 0xffffffff, 0x0)
        /home/mattia/github/ble/linux/hci/buffer.go:19 +0x24
github.com/rigado/ble/linux/hci.(*HCI).Init(0x10f8000, 0x10961f8, 0x1093c5c)
        /home/mattia/github/ble/linux/hci/hci.go:172 +0x5b8
github.com/rigado/ble/linux.NewDeviceWithNameAndHandler(0x7ed6ddbc, 0x4, 0x0, 0x0, 0x1093c5c, 0x2, 0x2, 0x10, 0x10a2200, 0x1)
        /home/mattia/github/ble/linux/device.go:33 +0x60
github.com/mfiumara/mynewt-newtmgr/newtmgr/bll.(*BllXport).Start(0x10a2200, 0x10a2200, 0x10ae1b0)
        /home/mattia/github/mynewt-newtmgr/newtmgr/bll/bll_xport.go:78 +0x124
github.com/mfiumara/mynewt-newtmgr/newtmgr/cli.GetXport(0x10ae180, 0x0, 0x10961f0, 0x200)
        /home/mattia/github/mynewt-newtmgr/newtmgr/cli/common.go:163 +0x21c
github.com/mfiumara/mynewt-newtmgr/newtmgr/cli.buildBllSesn(0x1098840, 0x0, 0x30, 0x581b10, 0x1)
        /home/mattia/github/mynewt-newtmgr/newtmgr/cli/common.go:272 +0x74
github.com/mfiumara/mynewt-newtmgr/newtmgr/cli.GetSesn(0x8010100, 0x0, 0x1093e9c, 0x1c42d4)
        /home/mattia/github/mynewt-newtmgr/newtmgr/cli/common.go:314 +0x68
github.com/mfiumara/mynewt-newtmgr/newtmgr/cli.imageStateListCmd(0x10cca00, 0x10b25c0, 0x0, 0x8)
        /home/mattia/github/mynewt-newtmgr/newtmgr/cli/image.go:92 +0x14
github.com/spf13/cobra.(*Command).execute(0x10cca00, 0x10b2480, 0x8, 0x8, 0x10cca00, 0x10b2480)
        /home/mattia/go/pkg/mod/github.com/spf13/cobra@v0.0.5/command.go:830 +0x1e8
github.com/spf13/cobra.(*Command).ExecuteC(0x10cc000, 0x63c914, 0x1104780, 0x0)
        /home/mattia/go/pkg/mod/github.com/spf13/cobra@v0.0.5/command.go:914 +0x230
github.com/spf13/cobra.(*Command).Execute(...)
        /home/mattia/go/pkg/mod/github.com/spf13/cobra@v0.0.5/command.go:864
main.main()
        /home/mattia/github/mynewt-newtmgr/newtmgr/newtmgr.go:111 +0xd8
```
This PR fixes this to at least check for a valid channel size, but does not resolve the underlying non-responsive HCI device issue. I'll follow up on this with a separate PR.