### PR TITLE
Handle encryption changed event

### DIFF
--- a/client.go
+++ b/client.go
@@ -78,5 +78,5 @@ type Client interface {
 
 	Pair(AuthData, time.Duration) error
 
-	StartEncryption() error
+	StartEncryption(c chan EncryptionChangedInfo) error
 }

--- a/conn.go
+++ b/conn.go
@@ -6,6 +6,12 @@ import (
 	"time"
 )
 
+type EncryptionChangedInfo struct {
+	Status  int
+	Err     error
+	Enabled bool
+}
+
 // Conn implements a L2CAP connection.
 type Conn interface {
 	io.ReadWriteCloser
@@ -39,5 +45,5 @@ type Conn interface {
 
 	Pair(AuthData, time.Duration) error
 
-	StartEncryption() error
+	StartEncryption(change chan EncryptionChangedInfo) error
 }

--- a/linux/gatt/client.go
+++ b/linux/gatt/client.go
@@ -462,6 +462,6 @@ func (p *Client) Pair(authData ble.AuthData, to time.Duration) error {
 	return p.conn.Pair(authData, to)
 }
 
-func (p *Client) StartEncryption() error {
-	return p.conn.StartEncryption()
+func (p *Client) StartEncryption(ch chan ble.EncryptionChangedInfo) error {
+	return p.conn.StartEncryption(ch)
 }

--- a/linux/hci/bond.go
+++ b/linux/hci/bond.go
@@ -2,18 +2,19 @@ package hci
 
 type bondInfo struct {
 	longTermKey []byte
-	ediv uint16
-	randVal uint64
-	legacy bool
+	ediv        uint16
+	randVal     uint64
+	legacy      bool
 }
 
-type BondManager interface{
+type BondManager interface {
 	Find(addr string) (BondInfo, error)
 	Save(string, BondInfo) error
 	Exists(addr string) bool
+	Delete(addr string) error
 }
 
-type BondInfo interface{
+type BondInfo interface {
 	LongTermKey() []byte
 	EDiv() uint16
 	Random() uint64
@@ -22,10 +23,10 @@ type BondInfo interface{
 
 func NewBondInfo(longTermKey []byte, ediv uint16, random uint64, legacy bool) BondInfo {
 	return &bondInfo{
-		longTermKey:longTermKey,
-		ediv:ediv,
-		randVal:random,
-		legacy:legacy,
+		longTermKey: longTermKey,
+		ediv:        ediv,
+		randVal:     random,
+		legacy:      legacy,
 	}
 }
 
@@ -44,6 +45,3 @@ func (b *bondInfo) Random() uint64 {
 func (b *bondInfo) Legacy() bool {
 	return b.legacy
 }
-
-
-

--- a/linux/hci/conn.go
+++ b/linux/hci/conn.go
@@ -422,15 +422,15 @@ func (c *Conn) handleEncryptionChanged(status uint8, enabled uint8) {
 	}
 
 	info := ble.EncryptionChangedInfo{Status: int(status), Err: err, Enabled: enabled == 0x01}
-	if c.encChanged == nil {
-		logger.Info("encryption changed result - status:", status, "; err:", err)
-	} else {
+	if c.encChanged != nil {
 		select {
 		case c.encChanged <- info:
 			return
 		default:
 			_ = logger.Error("failed to send encryption changed status to channel:", info)
 		}
+	} else {
+		logger.Info("encryption changed result - status:", status, "; err:", err)
 	}
 }
 

--- a/linux/hci/conn.go
+++ b/linux/hci/conn.go
@@ -65,7 +65,8 @@ type Conn struct {
 	// leFrame is set to be true when the LE Credit based flow control is used.
 	leFrame bool
 
-	smp SmpManager
+	smp        SmpManager
+	encChanged chan ble.EncryptionChangedInfo
 }
 
 type Encrypter interface {
@@ -137,8 +138,14 @@ func (c *Conn) Pair(authData ble.AuthData, to time.Duration) error {
 	return c.smp.Pair(authData, to)
 }
 
-func (c *Conn) StartEncryption() error {
-	return c.smp.StartEncryption()
+func (c *Conn) StartEncryption(ch chan ble.EncryptionChangedInfo) error {
+	c.encChanged = ch
+	err := c.smp.StartEncryption()
+	if err != nil {
+		c.encChanged = nil
+	}
+
+	return err
 }
 
 // Read copies re-assembled L2CAP PDUs into sdu.
@@ -401,6 +408,30 @@ func (c *Conn) recombine() error {
 		logger.Info("recombine()", "unrecognized CID", fmt.Sprintf("%04X, [%X]", p.cid(), p))
 	}
 	return nil
+}
+
+func (c *Conn) handleEncryptionChanged(status uint8, enabled uint8) {
+	var err error
+	if status != 0x00 {
+		cmdErr := ErrCommand(status)
+		err = fmt.Errorf(errCmd[cmdErr])
+		e := c.smp.DeleteBondInfo()
+		if e != nil {
+			_ = logger.Error("failed to delete bond info", e)
+		}
+	}
+
+	info := ble.EncryptionChangedInfo{Status: int(status), Err: err, Enabled: enabled == 0x01}
+	if c.encChanged == nil {
+		logger.Info("encryption changed result - status:", status, "; err:", err)
+	} else {
+		select {
+		case c.encChanged <- info:
+			return
+		default:
+			_ = logger.Error("failed to send encryption changed status to channel:", info)
+		}
+	}
 }
 
 // Disconnected returns a receiving channel, which is closed when the connection disconnects.

--- a/linux/hci/hci.go
+++ b/linux/hci/hci.go
@@ -329,6 +329,9 @@ func (h *HCI) send(c Command) ([]byte, error) {
 
 	p := &pkt{c, make(chan []byte)}
 
+	//verify opcode is free before asking for the command buffer
+	//this ensures that the command buffer is only taken if
+	//the command can be sent
 	if h.checkOpCodeFree(c.OpCode()) != nil {
 		return nil, fmt.Errorf("command with opcode %v pending", c.OpCode())
 	}
@@ -868,6 +871,7 @@ func (h *HCI) handleEncryptionChange(b []byte) error {
 
 func (h *HCI) handleNumberOfCompletedPackets(b []byte) error {
 	e := evt.NumberOfCompletedPackets(b)
+	logger.Debug("hci", "number of comp packets:", fmt.Sprintf("% X", b))
 	h.muConns.Lock()
 	defer h.muConns.Unlock()
 	for i := 0; i < int(e.NumberOfHandles()); i++ {

--- a/linux/hci/hci.go
+++ b/linux/hci/hci.go
@@ -368,7 +368,7 @@ func (h *HCI) send(c Command) ([]byte, error) {
 		fmt.Println("no response to command")
 		fmt.Println("pending commands:")
 		fmt.Printf("cmd: %x pkt: %s\n", c.OpCode(), hex.EncodeToString(b[:4+c.Len()]))
-		h.dispatchError(err)
+		//h.dispatchError(err)
 		ret = nil
 	case <-h.done:
 		err = h.err

--- a/linux/hci/hci.go
+++ b/linux/hci/hci.go
@@ -371,7 +371,7 @@ func (h *HCI) send(c Command) ([]byte, error) {
 	var err error
 
 	// emergency timeout to prevent calls from locking up if the HCI
-	// interface doesn't respond.  Responsed here should normally be fast
+	// interface doesn't respond. Responses should normally be fast
 	// a timeout indicates a major problem with HCI.
 	select {
 	case <-time.After(3 * time.Second):
@@ -379,7 +379,7 @@ func (h *HCI) send(c Command) ([]byte, error) {
 		fmt.Println("no response to command")
 		fmt.Println("pending commands:")
 		fmt.Printf("cmd: %x pkt: %s\n", c.OpCode(), hex.EncodeToString(b[:4+c.Len()]))
-		//h.dispatchError(err)
+		h.dispatchError(err)
 		ret = nil
 	case <-h.done:
 		err = h.err

--- a/linux/hci/hci.go
+++ b/linux/hci/hci.go
@@ -841,6 +841,17 @@ func (h *HCI) handleDisconnectionComplete(b []byte) error {
 }
 
 func (h *HCI) handleEncryptionChange(b []byte) error {
+	e := evt.EncryptionChange(b)
+	h.muConns.Lock()
+	defer h.muConns.Unlock()
+	c, found := h.conns[e.ConnectionHandle()]
+	if !found {
+		_ = logger.Error("encryption changed event for unknown connection handle:", e.ConnectionHandle())
+	}
+
+	//pass to connection to handle status
+	c.handleEncryptionChanged(e.Status(), e.EncryptionEnabled())
+
 	return nil
 }
 

--- a/linux/hci/smp.go
+++ b/linux/hci/smp.go
@@ -11,12 +11,12 @@ type smpDispatcher struct {
 }
 
 const (
-	IoCapsDisplayOnly		= 0x00
-	IoCapsDisplayYesNo      = 0x01
-	IoCapsKeyboardOnly      = 0x02
-	IoCapsNone              = 0x03
-	IoCapsKeyboardDisplay   = 0x04
-	IoCapsReservedStart     = 0x05
+	IoCapsDisplayOnly     = 0x00
+	IoCapsDisplayYesNo    = 0x01
+	IoCapsKeyboardOnly    = 0x02
+	IoCapsNone            = 0x03
+	IoCapsKeyboardDisplay = 0x04
+	IoCapsReservedStart   = 0x05
 )
 
 type OobDataFlag byte
@@ -37,6 +37,7 @@ type SmpManager interface {
 	Handle(data []byte) error
 	Pair(authData ble.AuthData, to time.Duration) error
 	BondInfoFor(addr string) BondInfo
+	DeleteBondInfo() error
 	StartEncryption() error
 	SetWritePDUFunc(func([]byte) (int, error))
 	SetEncryptFunc(func(BondInfo) error)

--- a/linux/hci/smp/manager.go
+++ b/linux/hci/smp/manager.go
@@ -100,7 +100,6 @@ func (m *manager) Handle(in []byte) error {
 }
 
 func (m *manager) Pair(authData ble.AuthData, to time.Duration) error {
-
 	if m.t.pairing.state != Init {
 		return fmt.Errorf("Pairing already in progress")
 	}
@@ -152,6 +151,10 @@ func (m *manager) BondInfoFor(addr string) hci.BondInfo {
 	}
 
 	return bi
+}
+
+func (m *manager) DeleteBondInfo() error {
+	return m.bondManager.Delete(hex.EncodeToString(m.pairing.remoteAddr))
 }
 
 func (m *manager) LegacyPairingInfo() (bool, []byte) {


### PR DESCRIPTION
This change properly handles the encryption changed even including sending the information back to the caller.

* Process encryption changed in connection and send information back to the caller via a channel
* StartEncryption now requires a channel
* Delete bond information when encryption changed information notes that the bond data is incorrect (could be deleted on the device side or out of date)