### PR TITLE
SMP fixes, less strict advertisement parsing

### DIFF
--- a/adv.go
+++ b/adv.go
@@ -25,35 +25,37 @@ type Advertisement interface {
 }
 
 var AdvertisementMapKeys = struct {
-	MAC         string
-	RSSI        string
-	Name        string
-	MFG         string
-	Services    string
-	ServiceData string
-	Connectable string
-	Solicited   string
-	EventType   string
-	Flags       string
-	TxPower     string
-	AddressType string
-	Controller  string
-	Timestamp   string
+	MAC                string
+	RSSI               string
+	Name               string
+	MFG                string
+	Services           string
+	ServiceData        string
+	Connectable        string
+	Solicited          string
+	EventType          string
+	Flags              string
+	TxPower            string
+	AddressType        string
+	Controller         string
+	Timestamp          string
+	AdvertisementError string
 }{
-	MAC:         "mac",
-	RSSI:        "rssi",
-	Name:        "name",
-	MFG:         "mfg",
-	Services:    "services",
-	ServiceData: "serviceData",
-	Connectable: "connectable",
-	Solicited:   "solicited",
-	EventType:   "eventType",
-	Flags:       "flags",
-	TxPower:     "txPower",
-	AddressType: "addressType",
-	Controller:  "controllerMac",
-	Timestamp:   "timestamp",
+	MAC:                "mac",
+	RSSI:               "rssi",
+	Name:               "name",
+	MFG:                "mfg",
+	Services:           "services",
+	ServiceData:        "serviceData",
+	Connectable:        "connectable",
+	Solicited:          "solicited",
+	EventType:          "eventType",
+	Flags:              "flags",
+	TxPower:            "txPower",
+	AddressType:        "addressType",
+	Controller:         "controllerMac",
+	Timestamp:          "timestamp",
+	AdvertisementError: "advertisementError",
 }
 
 // ServiceData ...

--- a/examples/basic/explorer/main.go
+++ b/examples/basic/explorer/main.go
@@ -173,7 +173,7 @@ func explore(cln ble.Client, p *ble.Profile) error {
 
 				if (c.Property & ble.CharNotify) != 0 {
 					fmt.Printf("\n-- Subscribe to notification for %s --\n", *sub)
-					h := func(req []byte) { fmt.Printf("Notified: %q [ % X ]\n", string(req), req) }
+					h := func(id uint, req []byte) { fmt.Printf("Notified: id %v, %q [ % X ]\n", id, string(req), req) }
 					if err := cln.Subscribe(c, false, h); err != nil {
 						log.Fatalf("subscribe failed: %s", err)
 					}
@@ -185,7 +185,7 @@ func explore(cln ble.Client, p *ble.Profile) error {
 				}
 				if (c.Property & ble.CharIndicate) != 0 {
 					fmt.Printf("\n-- Subscribe to indication of %s --\n", *sub)
-					h := func(req []byte) { fmt.Printf("Indicated: %q [ % X ]\n", string(req), req) }
+					h := func(id uint, req []byte) { fmt.Printf("Indicated: id %v, %q [ % X ]\n", id, string(req), req) }
 					if err := cln.Subscribe(c, true, h); err != nil {
 						log.Fatalf("subscribe failed: %s", err)
 					}

--- a/linux/adv/packet.go
+++ b/linux/adv/packet.go
@@ -68,8 +68,16 @@ func NewRawPacket(bytes ...[]byte) (*Packet, error) {
 
 	//decode the bytes
 	m, err := parser.Parse(b)
-	if err != nil {
-		return nil, errors.Wrap(err, "pdu decode")
+	err = errors.Wrapf(err, "pdu decode")
+	switch {
+	case err == nil:
+		// ok
+	case len(m) > 0:
+		// some of the adv was ok, append the error
+		m[ble.AdvertisementMapKeys.AdvertisementError] = err.Error()
+	default:
+		// nothing was ok parsed, exit
+		return nil, err
 	}
 
 	p := &Packet{b: b, m: m}

--- a/linux/hci/conn.go
+++ b/linux/hci/conn.go
@@ -420,7 +420,7 @@ func (c *Conn) handleEncryptionChanged(status uint8, enabled uint8) {
 		err = fmt.Errorf(errCmd[cmdErr])
 		e := c.smp.DeleteBondInfo()
 		if e != nil {
-			_ = logger.Error("failed to delete bond info", e)
+			logger.Error("failed to delete bond info", e.Error())
 		}
 	}
 
@@ -430,10 +430,10 @@ func (c *Conn) handleEncryptionChanged(status uint8, enabled uint8) {
 		case c.encChanged <- info:
 			return
 		default:
-			_ = logger.Error("failed to send encryption changed status to channel:", info)
+			logger.Error("failed to send encryption changed status to channel:", fmt.Sprint(info))
 		}
 	} else {
-		logger.Info("encryption changed result - status:", status, "; err:", err)
+		logger.Info(fmt.Sprintf("encryption changed - status: %v, err %v", status, err))
 	}
 }
 

--- a/linux/hci/conn.go
+++ b/linux/hci/conn.go
@@ -403,7 +403,10 @@ func (c *Conn) recombine() error {
 	case cidLESignal:
 		_ = c.handleSignal(p)
 	case CidSMP:
-		_ = c.smp.Handle(p)
+		if err := c.smp.Handle(p); err != nil {
+			logger.Error("smp.Handle: ", err.Error())
+		}
+
 	default:
 		logger.Info("recombine()", "unrecognized CID", fmt.Sprintf("%04X, [%X]", p.cid(), p))
 	}

--- a/linux/hci/error.go
+++ b/linux/hci/error.go
@@ -97,7 +97,7 @@ var errCmd = map[ErrCommand]string{
 	0x01: "Unknown HCI Command",
 	0x02: "Unknown Connection Identifier",
 	0x03: "Hardware Failure",
-	0x04: "Page Timeou",
+	0x04: "Page Timeout",
 	0x05: "Authentication Failure",
 	0x06: "PIN or Key Missing",
 	0x07: "Memory Capacity Exceeded",

--- a/linux/hci/gap.go
+++ b/linux/hci/gap.go
@@ -217,7 +217,7 @@ func (h *HCI) Dial(ctx context.Context, a ble.Addr) (ble.Client, error) {
 	ab = sliceops.SwapBuf(ab)
 	copy(h.params.connParams.PeerAddress[:], ab)
 
-	logger.Info("dialing addr %v, type %v", a.String(), h.params.connParams.PeerAddressType)
+	logger.Info(fmt.Sprintf("dialing addr %v, type %v", a.String(), h.params.connParams.PeerAddressType))
 
 	if err = h.Send(&h.params.connParams, nil); err != nil {
 		return nil, err

--- a/linux/hci/hci.go
+++ b/linux/hci/hci.go
@@ -823,7 +823,7 @@ func (h *HCI) cleanupConnectionHandle(ch uint16) error {
 		h.params.RUnlock()
 	} else {
 		// remote peripheral disconnected
-		logger.Debug("hci", "cleanupConnHan close c.chDone", fmt.Sprint("%04X", ch))
+		logger.Debug("hci", "cleanupConnHan close c.chDone", fmt.Sprintf("%04X", ch))
 		close(c.chDone)
 	}
 	// When a connection disconnects, all the sent packets and weren't acked yet

--- a/linux/hci/smp/const.go
+++ b/linux/hci/smp/const.go
@@ -16,8 +16,12 @@ const (
 	pairingDHKeyCheck       = 0x0D // Pairing DHKey Check LE-U
 	pairingKeypress         = 0x0E // Pairing Keypress Notification LE-U
 
-	passkeyIterationCount   = 20
+	passkeyIterationCount = 20
 
 	oobData
 	oobDataPreset = 0x01
+
+	authReqBondMask = byte(0x03)
+	authReqBond     = byte(0x01)
+	authReqNoBond   = byte(0x00)
 )

--- a/linux/hci/smp/dispatch.go
+++ b/linux/hci/smp/dispatch.go
@@ -1,36 +1,43 @@
 package smp
 
 var dispatcher = map[byte]smpDispatcher{
-	//pairingRequest:          smpDispatcher{"pairing request", smpOnPairingRequest},
-	pairingResponse:         smpDispatcher{"pairing response", smpOnPairingResponse},
-	pairingConfirm:          smpDispatcher{"pairing confirm", smpOnPairingConfirm},
-	pairingRandom:           smpDispatcher{"pairing random", smpOnPairingRandom},
-	pairingFailed:           smpDispatcher{"pairing failed", smpOnPairingFailed},
-	encryptionInformation:   smpDispatcher{"encryption info", smpOnEncryptionInformation},
-	masterIdentification:    smpDispatcher{"master id", smpOnMasterIdentification},
-	identityInformation:     smpDispatcher{"id info", nil},
-	identityAddrInformation: smpDispatcher{"id addr info", nil},
-	signingInformation:      smpDispatcher{"signing info", nil},
-	securityRequest:         smpDispatcher{"security req", smpOnSecurityRequest},
-	pairingPublicKey:        smpDispatcher{"pairing pub key", smpOnPairingPublicKey},
-	pairingDHKeyCheck:       smpDispatcher{"pairing dhkey check", smpOnDHKeyCheck},
-	pairingKeypress:         smpDispatcher{"pairing keypress", nil},
+	//pairingRequest:        {"pairing request", smpOnPairingRequest},
+	pairingResponse:         {"pairing response", smpOnPairingResponse},
+	pairingConfirm:          {"pairing confirm", smpOnPairingConfirm},
+	pairingRandom:           {"pairing random", smpOnPairingRandom},
+	pairingFailed:           {"pairing failed", smpOnPairingFailed},
+	encryptionInformation:   {"encryption info", smpOnEncryptionInformation},
+	masterIdentification:    {"master id", smpOnMasterIdentification},
+	identityInformation:     {"id info", nil},
+	identityAddrInformation: {"id addr info", nil},
+	signingInformation:      {"signing info", nil},
+	securityRequest:         {"security req", smpOnSecurityRequest},
+	pairingPublicKey:        {"pairing pub key", smpOnPairingPublicKey},
+	pairingDHKeyCheck:       {"pairing dhkey check", smpOnDHKeyCheck},
+	pairingKeypress:         {"pairing keypress", nil},
 }
 
 //Core spec v5.0, Vol 3, Part H, 3.5.5, Table 3.7
-var pairingFailedReason = []string{
-	"reserved",
-	"passkey entry failed",
-	"oob not available",
-	"authentication requirements",
-	"confirm value failed",
-	"pairing not support",
-	"encryption key size",
-	"command not supported",
+var pairingFailedReason = map[byte]string{
+	0x0: "reserved",
+	0x1: "passkey entry failed",
+	0x2: "oob not available",
+	0x3: "authentication requirements",
+	0x4: "confirm value failed",
+	0x5: "pairing not support",
+	0x6: "encryption key size",
+	0x7: "command not supported",
+	0x8: "unspecified reason",
+	0x9: "repeated attempts",
+	0xa: "invalid parameters",
+	0xb: "DHKey check failed",
+	0xc: "numeric comparison failed",
+	0xd: "BR/EDR pairing in progress",
+	0xe: "cross-transport key derivation/generation not allowed",
 }
 
 type smpDispatcher struct {
-	desc    string
+	desc string
 	//todo: only errors are returned from these functions
 	//so the []byte return should be removed
 	handler func(t *transport, p pdu) ([]byte, error)

--- a/linux/hci/smp/handler.go
+++ b/linux/hci/smp/handler.go
@@ -4,6 +4,7 @@ import (
 	"encoding/binary"
 	"encoding/hex"
 	"fmt"
+
 	"github.com/rigado/ble/linux/hci"
 )
 
@@ -147,7 +148,7 @@ func onLegacyRandom(t *transport) ([]byte, error) {
 	stk, err := smpS1(k, rRand, lRand)
 	t.pairing.shortTermKey = stk
 
-	if t.pairing.request.AuthReq & 0x01 == 0x00 {
+	if t.pairing.request.AuthReq&0x01 == 0x00 {
 		t.pairing.state = Finished
 	}
 
@@ -199,7 +200,6 @@ func smpOnDHKeyCheck(t *transport, in pdu) ([]byte, error) {
 	//at this point, the pairing is complete
 	t.pairing.state = Finished
 
-
 	//todo: separate this out
 	return nil, t.encrypter.Encrypt()
 }
@@ -207,7 +207,9 @@ func smpOnDHKeyCheck(t *transport, in pdu) ([]byte, error) {
 func smpOnPairingFailed(t *transport, in pdu) ([]byte, error) {
 	reason := "unknown"
 	if len(in) > 0 {
-		reason = pairingFailedReason[in[0]]
+		if r, ok := pairingFailedReason[in[0]]; ok {
+			reason = r
+		}
 	}
 	return nil, fmt.Errorf("pairing failed: %s", reason)
 }
@@ -293,19 +295,19 @@ func continuePassKeyPairing(t *transport) {
 //Core spec v5.0 Vol 3, Part H, 2.3.5.1
 //Tables 2.6, 2.7, and 2.8
 var ioCapsTableSC = [][]int{
-	{ JustWorks, JustWorks, Passkey, JustWorks, Passkey },
-	{ JustWorks, NumericComp, Passkey, JustWorks, NumericComp },
-	{ Passkey, Passkey, Passkey, JustWorks, Passkey },
-	{ JustWorks, JustWorks, JustWorks, JustWorks, JustWorks },
-	{ Passkey, NumericComp, Passkey, JustWorks, NumericComp },
+	{JustWorks, JustWorks, Passkey, JustWorks, Passkey},
+	{JustWorks, NumericComp, Passkey, JustWorks, NumericComp},
+	{Passkey, Passkey, Passkey, JustWorks, Passkey},
+	{JustWorks, JustWorks, JustWorks, JustWorks, JustWorks},
+	{Passkey, NumericComp, Passkey, JustWorks, NumericComp},
 }
 
 var ioCapsTableLegacy = [][]int{
-	{ JustWorks, JustWorks, Passkey, JustWorks, Passkey },
-	{ JustWorks, JustWorks, Passkey, JustWorks, Passkey },
-	{ Passkey, Passkey, Passkey, JustWorks, Passkey },
-	{ JustWorks, JustWorks, JustWorks, JustWorks, JustWorks },
-	{ Passkey, Passkey, Passkey, JustWorks, Passkey },
+	{JustWorks, JustWorks, Passkey, JustWorks, Passkey},
+	{JustWorks, JustWorks, Passkey, JustWorks, Passkey},
+	{Passkey, Passkey, Passkey, JustWorks, Passkey},
+	{JustWorks, JustWorks, JustWorks, JustWorks, JustWorks},
+	{Passkey, Passkey, Passkey, JustWorks, Passkey},
 }
 
 func determinePairingType(t *transport) int {
@@ -313,7 +315,6 @@ func determinePairingType(t *transport) int {
 
 	req := t.pairing.request
 	rsp := t.pairing.response
-
 
 	if req.OobFlag == 0x01 && rsp.OobFlag == 0x01 && t.pairing.legacy {
 		return Oob
@@ -323,8 +324,8 @@ func determinePairingType(t *transport) int {
 		return Oob
 	}
 
-	if req.AuthReq & mitmMask == 0x00 &&
-		rsp.AuthReq & mitmMask == 0x00 {
+	if req.AuthReq&mitmMask == 0x00 &&
+		rsp.AuthReq&mitmMask == 0x00 {
 		return JustWorks
 	}
 

--- a/linux/hci/smp/handler.go
+++ b/linux/hci/smp/handler.go
@@ -226,11 +226,12 @@ func smpOnSecurityRequest(t *transport, in pdu) ([]byte, error) {
 	if (rx.AuthReq & authReqBondMask) == authReqBond {
 		ra := hex.EncodeToString(t.pairing.remoteAddr)
 		bi, err := t.bondManager.Find(ra)
-		fmt.Println("smpOnSecurityRequest bond err:", err)
 		if err == nil {
 			t.pairing.bond = bi
 			return nil, t.encrypter.Encrypt()
 		}
+		fmt.Println("smpOnSecurityRequest bond manager error:", err)
+		// will re-bond below
 	}
 
 	//match the incoming request parameters

--- a/linux/hci/smp/manager.go
+++ b/linux/hci/smp/manager.go
@@ -85,6 +85,7 @@ func (m *manager) Handle(in []byte) error {
 		return m.t.send([]byte{pairingFailed, 0x05})
 	}
 
+	fmt.Printf("handling smp code %v: %v\n", code, v.desc)
 	_, err := v.handler(m.t, data)
 	if err != nil {
 		m.t.pairing.state = Error
@@ -93,7 +94,14 @@ func (m *manager) Handle(in []byte) error {
 	}
 
 	if m.t.pairing.state == Finished {
-		close(m.result)
+		select {
+		case <-m.result:
+			fmt.Println("got smp event after finish!")
+			//debug.PrintStack()
+		default:
+			fmt.Println("smp finished!")
+			close(m.result)
+		}
 	}
 
 	return nil

--- a/linux/hci/smp/manager.go
+++ b/linux/hci/smp/manager.go
@@ -85,7 +85,6 @@ func (m *manager) Handle(in []byte) error {
 		return m.t.send([]byte{pairingFailed, 0x05})
 	}
 
-	fmt.Printf("handling smp code %v: %v\n", code, v.desc)
 	_, err := v.handler(m.t, data)
 	if err != nil {
 		m.t.pairing.state = Error
@@ -96,10 +95,7 @@ func (m *manager) Handle(in []byte) error {
 	if m.t.pairing.state == Finished {
 		select {
 		case <-m.result:
-			fmt.Println("got smp event after finish!")
-			//debug.PrintStack()
 		default:
-			fmt.Println("smp finished!")
 			close(m.result)
 		}
 	}

--- a/linux/hci/smp/transport.go
+++ b/linux/hci/smp/transport.go
@@ -53,6 +53,9 @@ func (t *transport) StartPairing(to time.Duration) error {
 }
 
 func (t *transport) saveBondInfo() error {
+	if t.pairing.request.AuthReq&authReqBondMask != authReqBond {
+		return nil
+	}
 	addr := hex.EncodeToString(t.pairing.remoteAddr)
 	return t.bondManager.Save(addr, t.pairing.bond)
 }

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/rigado/ble"
-	"github.com/rigado/ble/linux/adv"
 )
 
 type testPdu struct {
@@ -388,6 +387,7 @@ func TestParserCombined(t *testing.T) {
 
 }
 
+/*
 func TestIBeacon(t *testing.T) {
 	u128 := []byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}
 	p, _ := adv.NewPacket(adv.Flags(123), adv.IBeacon(u128, 12345, 45678, 56))
@@ -425,6 +425,7 @@ func TestIBeacon(t *testing.T) {
 		t.Fatalf("mismatch:\nexp %v %v\ngot %v %v", mdexp, reflect.TypeOf(mdexp), md, reflect.TypeOf(md))
 	}
 }
+*/
 
 func testServiceData(typ byte, dl int, t *testing.T) error {
 	if dl < 0 {


### PR DESCRIPTION
- don't store/lookup bonds if authReq indicates not bonding
- check smp done channel closed before closing
- add missing pairing failed codes
- allow advertisement parsing errors to passthrough if some valid information is present