### PR TITLE
improve logger, don't exit hci.sktProcessLoop() on unhandled events

### DIFF
--- a/addr.go
+++ b/addr.go
@@ -2,7 +2,6 @@ package ble
 
 import (
 	"encoding/hex"
-	"fmt"
 	"strings"
 )
 
@@ -29,7 +28,7 @@ func (a addr) Bytes() []byte {
 
 	out, err := hex.DecodeString(hexStr)
 	if err != nil {
-		fmt.Println("error decoding address:", err, a.String())
+		GetLogger().Errorf("error decoding address: %v, %v", err, a.String())
 	}
 
 	return out

--- a/darwin/device.go
+++ b/darwin/device.go
@@ -8,9 +8,9 @@ import (
 	"log"
 	"time"
 
-	"github.com/rigado/ble"
 	"github.com/pkg/errors"
 	"github.com/raff/goble/xpc"
+	"github.com/rigado/ble"
 
 	"sync"
 )
@@ -401,7 +401,7 @@ func (d *Device) HandleXpcEvent(event xpc.Dict, err error) {
 	}
 	m := msg(event)
 	args := msg(msg(event).args())
-	logger.Info("recv", "id", m.id(), "args", fmt.Sprintf("%v", m.args()))
+	logger.Infof("recv: id %v, args %v", m.id(), m.args())
 
 	switch m.id() {
 	case // Device event
@@ -569,7 +569,7 @@ func (d *Device) sendReq(x xpc.XPC, id int, args xpc.Dict) (msg, error) {
 }
 
 func (d *Device) sendCmd(x xpc.XPC, id int, args xpc.Dict) error {
-	logger.Info("send", "id", id, "args", fmt.Sprintf("%v", args))
+	logger.Infof("send: id %v, args %v", id, args)
 	x.Send(xpc.Dict{"kCBMsgId": id, "kCBMsgArgs": args}, false)
 	return nil
 }

--- a/darwin/log.go
+++ b/darwin/log.go
@@ -4,4 +4,4 @@ import (
 	"github.com/rigado/ble"
 )
 
-var logger = ble.Logger
+var logger = ble.GetLogger()

--- a/linux/att/client.go
+++ b/linux/att/client.go
@@ -27,13 +27,12 @@ type Client struct {
 	done       chan bool
 	connClosed chan struct{}
 
-	reqHandler map[int]func([]byte) error
-
 	server *Server
+	ble.Logger
 }
 
 // NewClient returns an Attribute Protocol Client.
-func NewClient(l2c ble.Conn, h NotificationHandler, done chan bool) *Client {
+func NewClient(l2c ble.Conn, h NotificationHandler, done chan bool, l ble.Logger) *Client {
 	c := &Client{
 		l2c:        l2c,
 		rspc:       make(chan []byte),
@@ -44,8 +43,9 @@ func NewClient(l2c ble.Conn, h NotificationHandler, done chan bool) *Client {
 		handler:    h,
 		done:       done,
 		connClosed: make(chan struct{}),
+		Logger:     l,
 	}
-	c.chTxBuf <- make([]byte, l2c.TxMTU(), l2c.TxMTU())
+	c.chTxBuf <- make([]byte, l2c.TxMTU())
 
 	go func() {
 		<-l2c.Disconnected()
@@ -57,9 +57,9 @@ func NewClient(l2c ble.Conn, h NotificationHandler, done chan bool) *Client {
 
 func (c *Client) WithServer(db *DB) *Client {
 	var err error
-	c.server, err = NewServer(db, c.l2c)
+	c.server, err = NewServer(db, c.l2c, c.Logger)
 	if err != nil {
-		logger.Info("failed to create server for client")
+		c.Errorf("client: failed to create server")
 	}
 
 	return c
@@ -109,7 +109,7 @@ func (c *Client) ExchangeMTU(clientRxMTU int) (serverRxMTU int, err error) {
 		c.l2c.SetTxMTU(txMTU)
 		// Put a re-allocated txBuf back to the channel.
 		// The txBuf has been captured in deferred function.
-		txBuf = make([]byte, txMTU, txMTU)
+		txBuf = make([]byte, txMTU)
 	}
 
 	return txMTU, nil
@@ -506,7 +506,7 @@ func (c *Client) sendCmd(b []byte) error {
 }
 
 func (c *Client) sendReq(b []byte) (rsp []byte, err error) {
-	logger.Debug("client", "req", fmt.Sprintf("% X", b))
+	c.Debugf("client: req % X", b)
 	if _, err := c.l2c.Write(b); err != nil {
 		return nil, errors.Wrap(err, "send ATT request failed")
 	}
@@ -521,7 +521,7 @@ func (c *Client) sendReq(b []byte) (rsp []byte, err error) {
 			// returns an ErrReqNotSupp response, and continue to wait
 			// the response to our request.
 			errRsp := newErrorResponse(rsp[0], 0x0000, ble.ErrReqNotSupp)
-			logger.Debug("client", "req", fmt.Sprintf("% X", b))
+			c.Debugf("client: rsp % X", b)
 			_, err := c.l2c.Write(errRsp)
 			if err != nil {
 				return nil, errors.Wrap(err, "unexpected ATT response received")
@@ -554,14 +554,14 @@ func (c *Client) asyncReqLoop() {
 		// keep trying?
 		select {
 		case <-c.done:
-			logger.Debug("[BLE ATT]: exited client async loop: done")
+			c.Debug("[BLE ATT]: exited client async loop: done")
 			return
 		case <-c.connClosed:
-			logger.Debug("[BLE ATT]: exited client async loop: conn closed")
+			c.Debug("[BLE ATT]: exited client async loop: conn closed")
 			return
 		default:
 			if c.l2c == nil {
-				logger.Debug("[BLE ATT] exited client async loop: l2c nil")
+				c.Debug("[BLE ATT] exited client async loop: l2c nil")
 				return
 			}
 			//ok
@@ -574,7 +574,7 @@ func (c *Client) asyncReqLoop() {
 		}
 		err := c.sendResp(rsp)
 		if err != nil {
-			logger.Info("client", "failed to send async att response for", fmt.Sprintf("%x", in[0]))
+			c.Errorf("client: failed to send async att response for: %X", in[0])
 		}
 	}
 }
@@ -608,14 +608,14 @@ func (c *Client) Loop() {
 		// keep trying?
 		select {
 		case <-c.done:
-			logger.Debug("exited client loop: done")
+			c.Debug("exited client loop: done")
 			return
 		case <-c.connClosed:
-			logger.Debug("exited client async loop: conn closed")
+			c.Debug("exited client async loop: conn closed")
 			return
 		default:
 			if c.l2c == nil {
-				logger.Debug("exited client loop: l2c nil")
+				c.Debug("exited client loop: l2c nil")
 				return
 			}
 			//ok
@@ -624,7 +624,7 @@ func (c *Client) Loop() {
 		n, err := c.l2c.Read(c.rxBuf)
 
 		if err != nil {
-			logger.Info("client", "read error", err.Error())
+			c.Errorf("client: read %v", err)
 			// We don't expect any error from the bearer (L2CAP ACL-U)
 			// Pass it along to the pending request, if any, and escape.
 			c.chErr <- err
@@ -633,34 +633,34 @@ func (c *Client) Loop() {
 
 		b := make([]byte, n)
 		copy(b, c.rxBuf)
-		logger.Debug("client", "data in", fmt.Sprintf("% X", b))
+		c.Debugf("client: data rx % X", b)
 
 		//all incoming requests are even numbered
 		//which means the last bit should be 0
 		if b[0]&0x01 == 0x00 {
 			select {
 			case <-c.done:
-				logger.Info("exited client loop: closed after async req rx")
+				c.Info("exited client loop: closed after async req rx")
 				return
 			case <-c.connClosed:
-				logger.Debug("exited client async loop: conn closed")
+				c.Debug("exited client async loop: conn closed")
 				return
 			case c.inc <- b:
 				continue
 			default:
-				logger.Info("client", "failed to enqueue request for", fmt.Sprintf("%x", b[0]))
+				c.Errorf("client: failed to enqueue request for", fmt.Sprintf("%x", b[0]))
 				continue
 			}
 		}
 
 		if (b[0] != HandleValueNotificationCode) && (b[0] != HandleValueIndicationCode) {
-			logger.Debug("client", "rsp", fmt.Sprintf("% X", c.rxBuf[:n]))
+			c.Debugf("client: rsp % X", c.rxBuf[:n])
 			select {
 			case <-c.done:
-				logger.Info("exited client loop: closed after rsp rx")
+				c.Info("exited client loop: closed after rsp rx")
 				return
 			case <-c.connClosed:
-				logger.Debug("exited client async loop: conn closed")
+				c.Debug("exited client async loop: conn closed")
 				return
 			case c.rspc <- b:
 				continue
@@ -668,24 +668,24 @@ func (c *Client) Loop() {
 		}
 
 		// Deliver the full request to upper layer.
-		logger.Debug("client", "notfi", fmt.Sprintf("% X", b))
+		c.Debugf("client: notif % X", b)
 		select {
 		case <-c.done:
-			logger.Info("exited client loop: closed after rx")
+			c.Info("exited client loop: closed after rx")
 			return
 		case <-c.connClosed:
-			logger.Debug("exited client async loop: conn closed")
+			c.Debug("exited client async loop: conn closed")
 			return
 		case ch <- asyncWork{handle: c.handler.HandleNotification, data: b}:
 			// ok
 		default:
 			// If this really happens, especially on a slow machine, enlarge the channel buffer.
-			_ = logger.Error("client", "req", "can't enqueue incoming notification.")
+			c.Error("client: req - can't enqueue incoming notification.")
 		}
 
 		// Always write aknowledgement for an indication, even it was an invalid request.
 		if b[0] == HandleValueIndicationCode {
-			logger.Debug("client", "req", fmt.Sprintf("% X", b))
+			c.Debugf("client: req % X", b)
 			_, _ = c.l2c.Write(confirmation)
 		}
 	}

--- a/linux/att/db.go
+++ b/linux/att/db.go
@@ -2,7 +2,6 @@ package att
 
 import (
 	"encoding/binary"
-	"fmt"
 
 	"github.com/rigado/ble"
 )
@@ -11,6 +10,7 @@ import (
 type DB struct {
 	attrs []*attr
 	base  uint16 // handle for first attr in attrs
+	ble.Logger
 }
 
 const (
@@ -62,7 +62,7 @@ func (r *DB) subrange(start, end uint16) []*attr {
 }
 
 // NewDB ...
-func NewDB(ss []*ble.Service, base uint16) *DB {
+func NewDB(ss []*ble.Service, base uint16, l ble.Logger) *DB {
 	h := base
 	var attrs []*attr
 	var aa []*attr
@@ -73,8 +73,10 @@ func NewDB(ss []*ble.Service, base uint16) *DB {
 		}
 		attrs = append(attrs, aa...)
 	}
-	DumpAttributes(attrs)
-	return &DB{attrs: attrs, base: base}
+
+	d := &DB{attrs: attrs, base: base, Logger: l}
+	d.DumpAttributes(attrs)
+	return d
 }
 
 func genSvcAttr(s *ble.Service, h uint16) (uint16, []*attr) {
@@ -143,15 +145,15 @@ func genDescAttr(d *ble.Descriptor, h uint16) *attr {
 }
 
 // DumpAttributes ...
-func DumpAttributes(aa []*attr) {
-	logger.Debug("server", "db", "Generating attribute table:")
-	logger.Debug("server", "db", "handle   endh   type")
+func (d *DB) DumpAttributes(aa []*attr) {
+	d.Debug("server: db - Generating attribute table:")
+	d.Debug("server: db - handle endh type")
 	for _, a := range aa {
 		if a.v != nil {
-			logger.Debug("server", "db", fmt.Sprintf("0x%04X 0x%04X 0x%s [% X]", a.h, a.endh, a.typ, a.v))
+			d.Debugf("server: db - 0x%04X 0x%04X 0x%s [% X]", a.h, a.endh, a.typ, a.v)
 			continue
 		}
-		logger.Debug("server", "db", fmt.Sprintf("0x%04X 0x%04X 0x%s", a.h, a.endh, a.typ))
+		d.Debugf("server: db - 0x%04X 0x%04X 0x%s", a.h, a.endh, a.typ)
 	}
 }
 

--- a/linux/att/log.go
+++ b/linux/att/log.go
@@ -1,6 +1,0 @@
-package att
-
-import "github.com/rigado/ble"
-
-var logger = ble.Logger
-

--- a/linux/hci/h4/frame.go
+++ b/linux/hci/h4/frame.go
@@ -56,16 +56,12 @@ func (f *frame) Assemble(b []byte) {
 		f.b = append(f.b, bb...)
 	}
 
-	// fmt.Printf("in  %0x\n", b)
-	// fmt.Printf("buf %0x\n", b)
-
 	rf, err := f.frame()
 	if err != nil {
 		return
 	}
 	out := make([]byte, len(rf))
 	copy(out, rf)
-	// fmt.Printf("out: %0x\n", out)
 	f.out <- out
 
 	// shift

--- a/linux/hci/hci.go
+++ b/linux/hci/hci.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io"
 	"net"
-	"strings"
 	"sync"
 	"time"
 
@@ -13,6 +12,7 @@ import (
 	"github.com/rigado/ble"
 	"github.com/rigado/ble/linux/hci/cmd"
 	"github.com/rigado/ble/linux/hci/evt"
+	"github.com/rigado/ble/sliceops"
 )
 
 // Command ...
@@ -57,6 +57,7 @@ func NewHCI(smp SmpManagerFactory, opts ...ble.Option) (*HCI, error) {
 		sktRxChan: make(chan []byte, 16), //todo pick a real number
 
 		vendorChan: make(chan []byte),
+		Logger:     ble.GetLogger(),
 	}
 	h.params.init()
 	if err := h.Option(opts...); err != nil {
@@ -133,6 +134,8 @@ type HCI struct {
 	cache ble.GattCache
 
 	vendorChan chan []byte
+
+	ble.Logger
 }
 
 // Init ...
@@ -203,7 +206,7 @@ func (h *HCI) cleanup() {
 	h.muConns.Unlock()
 
 	// kill all open connections w/o disconnect
-	logger.Debug("hci", fmt.Sprintf("cleanup(): found %v connection handles", len(hh)))
+	h.Debugf("hci: cleanup() found %v connection handles", len(hh))
 	for _, ch := range hh {
 		h.cleanupConnectionHandle(ch)
 	}
@@ -255,7 +258,7 @@ func (h *HCI) isOpen() bool {
 }
 
 func (h *HCI) init() error {
-	logger.Info("hci reset")
+	h.Debug("hci reset")
 	h.Send(&cmd.Reset{}, nil)
 
 	ReadBDADDRRP := cmd.ReadBDADDRRP{}
@@ -397,8 +400,7 @@ func (h *HCI) send(c Command) ([]byte, error) {
 	select {
 	case <-time.After(3 * time.Second):
 		err = fmt.Errorf("hci: no response to command, hci connection failed")
-		fmt.Println("no response to command:")
-		fmt.Printf("cmd: 0x%x (%v) pkt: %s\n", c.OpCode(), c.String(), hex.EncodeToString(b[:4+c.Len()]))
+		h.Errorf("%v - cmd 0x%x (%v) pkt: %x", err, c.OpCode(), c.String(), b[:4+c.Len()])
 		h.dispatchError(err)
 		ret = nil
 	case <-h.done:
@@ -430,13 +432,13 @@ func (h *HCI) sktProcessLoop() {
 
 		select {
 		case <-h.done:
-			fmt.Println("close requested")
+			h.Debugf("sktProcessLoop: close requested")
 			h.err = io.EOF
 			return
 
 		case p, ok = <-h.sktRxChan:
 			if !ok {
-				fmt.Println("socket rx closed")
+				h.Debugf("sktProcessLoop: rx channel closed")
 				h.err = io.EOF
 				return
 			}
@@ -444,21 +446,14 @@ func (h *HCI) sktProcessLoop() {
 		}
 
 		if err := h.handlePkt(p); err != nil {
-			// Some bluetooth devices may append vendor specific packets at the last,
-			// in this case, simply ignore them.
-			if strings.HasPrefix(err.Error(), "unsupported vendor packet:") {
-				_ = logger.Error("hci", "skt: ", err)
-			} else {
-				logger.Warn("skt handle error: %v", err)
-				// return
-			}
+			h.Warnf("sktProcessLoop: handlePacket - %v", err)
 		}
 	}
 }
 
 func (h *HCI) sktReadLoop() {
 	defer func() {
-		fmt.Println("sktRxLoop done")
+		h.Debugf("sktReadLoop: done, closing sktRxChan")
 		close(h.sktRxChan)
 	}()
 
@@ -531,7 +526,7 @@ func (h *HCI) handleACL(b []byte) error {
 	if c, ok := h.conns[handle]; ok {
 		c.chInPkt <- b
 	} else {
-		_ = logger.Warn("invalid connection handle on ACL packet", "handle:", handle)
+		h.Warnf("handleACL: invalid connection handle %v", handle)
 	}
 
 	return nil
@@ -760,16 +755,16 @@ func (h *HCI) handleCommandStatus(b []byte) error {
 func (h *HCI) handleLEConnectionComplete(b []byte) error {
 	e := evt.LEConnectionComplete(b)
 
-	status := e.Status()
-	if status != 0 {
-		logger.Warn("hci", "connection failed:", fmt.Sprintf("% X", b))
+	if status := e.Status(); status != 0 {
+		h.Warnf("connectionComplete: connection failed with status %X", status)
 		return nil
 	}
-	c := newConn(h, e)
-	h.muConns.Lock()
+
 	pa := e.PeerAddress()
-	addr := pa[:]
-	logger.Debug("hci", "connection complete", fmt.Sprintf("%04X: addr: %s, lecc evt: %s", e.ConnectionHandle(), hex.EncodeToString(addr), hex.EncodeToString(b)))
+	addr := hex.EncodeToString(sliceops.SwapBuf(pa[:]))
+	c := newConn(h, e, addr)
+	h.muConns.Lock()
+	h.Debugf("connectionComplete: handle %04x, addr %v, lecc evt %X", e.ConnectionHandle(), addr, b)
 	h.conns[e.ConnectionHandle()] = c
 	h.muConns.Unlock()
 
@@ -809,29 +804,28 @@ func (h *HCI) handleLEConnectionComplete(b []byte) error {
 }
 
 func (h *HCI) handleLEConnectionParameterRequest(b []byte) error {
-	logger.Warn("ignoring LEConnectionParameterRequest")
+	h.Warn("LEConnectionParameterRequest: ignored")
 	return nil
 }
 
 func (h *HCI) handleLEConnectionUpdateComplete(b []byte) error {
-	logger.Warn("ignoring LEConnectionUpdateComplete")
+	h.Warn("LEConnectionUpdateComplete: ignored")
 	return nil
 }
 
 func (h *HCI) cleanupConnectionHandle(ch uint16) error {
 	h.muConns.Lock()
 	defer h.muConns.Unlock()
-	logger.Debug("hci", "cleanupConnHan: looking for", fmt.Sprintf("%04X", ch))
+	h.Debugf("cleanupConnectionHandle %04X: getting device", ch)
 	c, found := h.conns[ch]
 	if !found {
 		return nil
-		//return fmt.Errorf("disconnecting an invalid handle %04X", ch)
 	}
 
-	logger.Debug("hci", "", fmt.Sprintf("cleanupConnHan %04X: found device with address %s\n", ch, c.RemoteAddr().String()))
-
+	h.Debugf("cleanupConnectionHandle %04X: found device with address %v", ch, c.RemoteAddr().String())
 	delete(h.conns, ch)
-	logger.Debug("hci", "cleanupConnHan close c.chInPkt", fmt.Sprintf("%04X", ch))
+
+	h.Debugf("cleanupConnectionHandle %04X: close c.chInPkt", ch)
 	close(c.chInPkt)
 
 	if !h.isOpen() && c.param.Role() == roleSlave {
@@ -846,7 +840,7 @@ func (h *HCI) cleanupConnectionHandle(ch uint16) error {
 		h.params.RUnlock()
 	} else {
 		// remote peripheral disconnected
-		logger.Debug("hci", "cleanupConnHan close c.chDone", fmt.Sprintf("%04X", ch))
+		h.Debugf("cleanupConnectionHandle %04X: close c.chDone", ch)
 		close(c.chDone)
 	}
 	// When a connection disconnects, all the sent packets and weren't acked yet
@@ -862,10 +856,9 @@ func (h *HCI) cleanupConnectionHandle(ch uint16) error {
 }
 
 func (h *HCI) handleDisconnectionComplete(b []byte) error {
-	logger.Debug("hci", "disconnect complete:", fmt.Sprintf("% X", b))
 	e := evt.DisconnectionComplete(b)
 	ch := e.ConnectionHandle()
-	logger.Debug("hci", "disconnect complete for handle", fmt.Sprintf("%04x", ch))
+	h.Debugf("disconnectComplete: handle %04X, reason %02X", ch, e.Reason())
 	if ErrCommand(e.Reason()) == ErrLocalHost {
 		//if the local host triggered the disconnect, the connection handle was already
 		//cleaned up. otherwise, the connection handle will be cleaned up because this
@@ -873,7 +866,7 @@ func (h *HCI) handleDisconnectionComplete(b []byte) error {
 		return nil
 	}
 
-	logger.Debug("hci", "cleaning up connection handle due to disconnect complete")
+	h.Debugf("disconnectComplete: cleaning up connection handle %04X", ch)
 	return h.cleanupConnectionHandle(ch)
 }
 
@@ -883,7 +876,7 @@ func (h *HCI) handleEncryptionChange(b []byte) error {
 	defer h.muConns.Unlock()
 	c, found := h.conns[e.ConnectionHandle()]
 	if !found {
-		logger.Error("encryption changed event for unknown connection handle:", fmt.Sprint(e.ConnectionHandle()))
+		h.Errorf("encryptionChanged: unknown connection handle %04X", e.ConnectionHandle())
 	}
 
 	//pass to connection to handle status
@@ -894,7 +887,7 @@ func (h *HCI) handleEncryptionChange(b []byte) error {
 
 func (h *HCI) handleNumberOfCompletedPackets(b []byte) error {
 	e := evt.NumberOfCompletedPackets(b)
-	logger.Debug("hci", "number of comp packets:", fmt.Sprintf("% X", b))
+	h.Debugf("numberOfCompletedPackets: % X", b)
 	h.muConns.Lock()
 	defer h.muConns.Unlock()
 	for i := 0; i < int(e.NumberOfHandles()); i++ {
@@ -914,15 +907,13 @@ func (h *HCI) handleNumberOfCompletedPackets(b []byte) error {
 func (h *HCI) handleLELongTermKeyRequest(b []byte) error {
 	//todo: probably need to support this
 	e := evt.LELongTermKeyRequest(b)
-	panic(nil)
-	return h.Send(&cmd.LELongTermKeyRequestNegativeReply{
-		ConnectionHandle: e.ConnectionHandle(),
-	}, nil)
+	h.Logger.Errorf("LELongTermKeyRequest: not supported - pkt %X", e)
+	return fmt.Errorf("not supported")
 }
 
 func (h *HCI) setAllowedCommands(n int) {
 	if n > chCmdBufChanSize {
-		fmt.Printf("hci.setAllowedCommands: warning, defaulting %d -> %d\n", n, chCmdBufChanSize)
+		h.Warnf("setAllowedCommands: defaulting %d -> %d", n, chCmdBufChanSize)
 		n = chCmdBufChanSize
 	}
 
@@ -966,10 +957,10 @@ func (h *HCI) handleVendorEvent(b []byte) error {
 func (h *HCI) dispatchError(e error) {
 	switch {
 	case h.errorHandler == nil:
-		fmt.Println(e)
+		h.Logger.Error(e)
 	case !h.isOpen():
 		//don't dispatch
-		fmt.Println("hci closing:", e)
+		h.Debug(e)
 	default:
 		h.errorHandler(e)
 	}
@@ -980,7 +971,9 @@ func (h *HCI) NOP() error {
 	return nil
 
 	// ReadBDADDRRP := cmd.ReadBDADDRRP{}
-	// err := h.Send(&cmd.ReadBDADDR{}, &ReadBDADDRRP)
-	// fmt.Println("NOP: err ", err)
-	// return err
+	// if err := h.Send(&cmd.ReadBDADDR{}, &ReadBDADDRRP); err != nil {
+	// 	h.Errorf("NOP: %v", err)
+	// 	return err
+	// }
+	// return nil
 }

--- a/linux/hci/hci.go
+++ b/linux/hci/hci.go
@@ -449,8 +449,8 @@ func (h *HCI) sktProcessLoop() {
 			if strings.HasPrefix(err.Error(), "unsupported vendor packet:") {
 				_ = logger.Error("hci", "skt: ", err)
 			} else {
-				h.err = fmt.Errorf("skt handle error: %v", err)
-				return
+				logger.Warn("skt handle error: %v", err)
+				// return
 			}
 		}
 	}

--- a/linux/hci/log.go
+++ b/linux/hci/log.go
@@ -1,7 +1,0 @@
-package hci
-
-import (
-	"github.com/rigado/ble"
-)
-
-var logger = ble.Logger

--- a/linux/hci/signal.go
+++ b/linux/hci/signal.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/binary"
 	"errors"
-	"fmt"
 	"time"
 
 	"github.com/rigado/ble/linux/hci/cmd"
@@ -101,12 +100,12 @@ func (c *Conn) sendResponse(code uint8, id uint8, r Signal) (int, error) {
 	if err := binary.Write(buf, binary.LittleEndian, data); err != nil {
 		return 0, err
 	}
-	logger.Debug("sig", "send", fmt.Sprintf("[%X]", buf.Bytes()))
+	c.Debugf("signal: send [%X]", buf.Bytes())
 	return c.writePDU(buf.Bytes())
 }
 
 func (c *Conn) handleSignal(p pdu) error {
-	logger.Debug("sig", "recv", fmt.Sprintf("[%X]", p))
+	c.Debugf("signal: recv [%X]", p)
 	// When multiple commands are included in an L2CAP packet and the packet
 	// exceeds the signaling MTU (MTUsig) of the receiver, a single Command Reject
 	// packet shall be sent in response. The identifier shall match the first Request
@@ -121,7 +120,7 @@ func (c *Conn) handleSignal(p pdu) error {
 				Data:   []byte{uint8(c.sigRxMTU), uint8(c.sigRxMTU >> 8)}, // Actual MTUsig.
 			})
 		if err != nil {
-			_ = logger.Error("send repsonse", fmt.Sprintf("%v", err))
+			c.Errorf("signal: sendRepsonse %v", err)
 		}
 		return nil
 	}

--- a/linux/hci/smp.go
+++ b/linux/hci/smp.go
@@ -1,8 +1,9 @@
 package hci
 
 import (
-	"github.com/rigado/ble"
 	"time"
+
+	"github.com/rigado/ble"
 )
 
 type smpDispatcher struct {
@@ -27,7 +28,7 @@ const (
 )
 
 type SmpManagerFactory interface {
-	Create(SmpConfig) SmpManager
+	Create(SmpConfig, ble.Logger) SmpManager
 	SetBondManager(BondManager)
 }
 

--- a/linux/hci/smp/context.go
+++ b/linux/hci/smp/context.go
@@ -20,11 +20,11 @@ const (
 	Oob
 )
 
-var pairingTypeStrings = []string{
-	"Just Works",
-	"Numeric Comparison",
-	"Passkey Entry",
-	"OOB Data",
+var pairingTypeStrings = map[int]string{
+	JustWorks:   "Just Works",
+	NumericComp: "Numeric Comparison",
+	Passkey:     "Passkey Entry",
+	Oob:         "OOB Data",
 }
 
 type pairingContext struct {

--- a/linux/hci/smp/context.go
+++ b/linux/hci/smp/context.go
@@ -55,6 +55,8 @@ type pairingContext struct {
 	state       PairingState
 	authData    ble.AuthData
 	bond        hci.BondInfo
+
+	ble.Logger
 }
 
 func (p *pairingContext) checkConfirm() error {
@@ -98,7 +100,7 @@ func (p *pairingContext) checkPasskeyConfirm() error {
 		return err
 	}
 
-	//fmt.Printf("i: %d, z: %x, c: %v, cc: %v, ra: %v, rb: %v\n", iteration, z,
+	//p.Debugf("i: %d, z: %x, c: %v, cc: %v, ra: %v, rb: %v", iteration, z,
 	//	hex.EncodeToString(p.remoteConfirm),
 	//	hex.EncodeToString(calcConf),
 	//	hex.EncodeToString(p.localRandom),
@@ -127,10 +129,10 @@ func (p *pairingContext) generatePassKeyConfirm() ([]byte, []byte) {
 
 	calcConf, err := smpF4(kax, kbx, nai, z)
 	if err != nil {
-		fmt.Println(err)
+		p.Errorf("generatePasskeyConfirm: %v", err)
 	}
 
-	//fmt.Printf("passkey confirm %d: z: %x, conf: %v\n", iteration, z, hex.EncodeToString(calcConf))
+	//p.Debugf("passkey confirm %d: z: %x, conf: %v", iteration, z, hex.EncodeToString(calcConf))
 
 	return calcConf, nai
 }

--- a/linux/hci/smp/crypto.go
+++ b/linux/hci/smp/crypto.go
@@ -4,6 +4,7 @@ import (
 	"encoding/binary"
 	"fmt"
 
+	"github.com/pkg/errors"
 	"github.com/rigado/ble/sliceops"
 )
 
@@ -47,8 +48,7 @@ func smpF5(w, n1, n2, a1, a2 []byte) ([]byte, []byte, error) {
 
 	t, err := aesCMAC(salt, w)
 	if err != nil {
-		fmt.Println("failed to generate f5 key:", err)
-		return nil, nil, err
+		return nil, nil, errors.Wrap(err, "generateF5Key")
 	}
 
 	m := length
@@ -61,8 +61,7 @@ func smpF5(w, n1, n2, a1, a2 []byte) ([]byte, []byte, error) {
 
 	macKey, err := aesCMAC(t, m)
 	if err != nil {
-		fmt.Println("failed to generate macKey:", err)
-		return nil, nil, err
+		return nil, nil, errors.Wrap(err, "generateMacKey")
 	}
 
 	//ltk generation bit
@@ -70,8 +69,7 @@ func smpF5(w, n1, n2, a1, a2 []byte) ([]byte, []byte, error) {
 
 	ltk, err := aesCMAC(t, m)
 	if err != nil {
-		fmt.Print("failed to generate ltk:", err)
-		return nil, nil, err
+		return nil, nil, errors.Wrap(err, "generateLTK")
 	}
 
 	return macKey, ltk, nil

--- a/linux/hci/smp/factory.go
+++ b/linux/hci/smp/factory.go
@@ -1,6 +1,9 @@
 package smp
 
-import "github.com/rigado/ble/linux/hci"
+import (
+	"github.com/rigado/ble"
+	"github.com/rigado/ble/linux/hci"
+)
 
 type factory struct {
 	bm hci.BondManager
@@ -10,8 +13,8 @@ func NewSmpFactory(bm hci.BondManager) *factory {
 	return &factory{bm}
 }
 
-func (f *factory) Create(config hci.SmpConfig) hci.SmpManager {
-	return NewSmpManager(config, f.bm)
+func (f *factory) Create(config hci.SmpConfig, l ble.Logger) hci.SmpManager {
+	return NewSmpManager(config, f.bm, l)
 }
 
 func (f *factory) SetBondManager(bm hci.BondManager) {

--- a/linux/hci/smp/handler.go
+++ b/linux/hci/smp/handler.go
@@ -45,7 +45,11 @@ func smpOnPairingResponse(t *transport, in pdu) ([]byte, error) {
 	t.pairing.legacy = isLegacy(rx.AuthReq)
 	t.pairing.pairingType = determinePairingType(t)
 
-	t.Debugf("smpOnPairingResponse: detected pairing type %v", pairingTypeStrings[t.pairing.pairingType])
+	pts, ok := pairingTypeStrings[t.pairing.pairingType]
+	if !ok {
+		return nil, fmt.Errorf("invalid pairing type %v", t.pairing.pairingType)
+	}
+	t.Debugf("smpOnPairingResponse: detected pairing type '%v'", pts)
 
 	if t.pairing.pairingType == Oob &&
 		len(t.pairing.authData.OOBData) == 0 {

--- a/linux/hci/smp/handler.go
+++ b/linux/hci/smp/handler.go
@@ -45,7 +45,7 @@ func smpOnPairingResponse(t *transport, in pdu) ([]byte, error) {
 	t.pairing.legacy = isLegacy(rx.AuthReq)
 	t.pairing.pairingType = determinePairingType(t)
 
-	fmt.Println("detected pairing type: ", pairingTypeStrings[t.pairing.pairingType])
+	t.Debugf("smpOnPairingResponse: detected pairing type %v", pairingTypeStrings[t.pairing.pairingType])
 
 	if t.pairing.pairingType == Oob &&
 		len(t.pairing.authData.OOBData) == 0 {
@@ -111,7 +111,7 @@ func onSecureRandom(t *transport) ([]byte, error) {
 	} else {
 		err := t.pairing.checkConfirm()
 		if err != nil {
-			fmt.Println(err)
+			t.Errorf("smpOnSecureRandom: checkConfirm - %v", err)
 			return nil, err
 		}
 	}
@@ -121,14 +121,14 @@ func onSecureRandom(t *transport) ([]byte, error) {
 	// move on to auth stage 2 (2.3.5.6.5) calc mackey, ltk
 	err := t.pairing.calcMacLtk()
 	if err != nil {
-		fmt.Println(err)
+		t.Errorf("smpOnSecureRandom: calcMacLtk - %v", err)
 		return nil, err
 	}
 
 	//send dhkey check
 	err = t.sendDHKeyCheck()
 	if err != nil {
-		fmt.Println(err)
+		t.Errorf("smpOnSecureRandom: sendDHKeyCheck - %v", err)
 		return nil, err
 	}
 
@@ -147,6 +147,9 @@ func onLegacyRandom(t *transport) ([]byte, error) {
 	//calculate STK
 	k := getLegacyParingTK(t.pairing.authData.Passkey)
 	stk, err := smpS1(k, rRand, lRand)
+	if err != nil {
+		return nil, err
+	}
 	t.pairing.shortTermKey = stk
 
 	if t.pairing.request.AuthReq&authReqBondMask == authReqNoBond {
@@ -199,7 +202,7 @@ func smpOnDHKeyCheck(t *transport, in pdu) ([]byte, error) {
 		return nil, err
 	}
 
-	fmt.Println("dhkey check pass!")
+	t.Debugf("dhKeyCheck: OK")
 	err = t.saveBondInfo()
 	if err != nil {
 		return nil, err
@@ -238,7 +241,7 @@ func smpOnSecurityRequest(t *transport, in pdu) ([]byte, error) {
 			t.pairing.bond = bi
 			return nil, t.encrypter.Encrypt()
 		}
-		fmt.Println("smpOnSecurityRequest bond manager error:", err)
+		t.Errorf("smpOnSecurityRequest: bond manager %v", err)
 		// will re-bond below
 	}
 
@@ -345,9 +348,8 @@ func determinePairingType(t *transport) int {
 
 	if rsp.IoCap >= hci.IoCapsReservedStart ||
 		req.IoCap >= hci.IoCapsReservedStart {
-		fmt.Printf("invalid io capabilities specified: req: %x rsp: %x\n",
-			req.IoCap, rsp.IoCap)
-		fmt.Println("using just works")
+		t.Warnf("determinePairingType: invalid io capabilities specified: req: %x rsp: %x", req.IoCap, rsp.IoCap)
+		t.Warnf("determinePairingType: using just works")
 		//todo: is this a valid assumption or should this return an error instead?
 		return JustWorks
 	}

--- a/log.go
+++ b/log.go
@@ -1,9 +1,73 @@
 package ble
 
-import log "github.com/mgutz/logxi/v1"
+import (
+	"os"
+	"sync"
 
-var Logger = log.New("ble")
+	"github.com/sirupsen/logrus"
+)
 
-func SetLogLevelDebug() {
-	Logger.SetLevel(log.LevelDebug)
+type Logger interface {
+	Info(...interface{})
+	Debug(...interface{})
+	Error(...interface{})
+	Warn(...interface{})
+
+	Infof(string, ...interface{})
+	Debugf(string, ...interface{})
+	Errorf(string, ...interface{})
+	Warnf(string, ...interface{})
+
+	ChildLogger(tags map[string]interface{}) Logger
+}
+
+var logger Logger
+var loggerMu sync.Mutex
+
+func SetLogLevelMax() {
+	l := GetLogger()
+
+	if lg, ok := l.(*defaultLogger); ok {
+		lg.Entry.Logger.SetLevel(logrus.TraceLevel)
+	} else {
+		// clean this up later
+		l.Error("non-default logger, don't know how to set level")
+	}
+}
+
+func SetLogger(l Logger) {
+	loggerMu.Lock()
+	defer loggerMu.Unlock()
+	logger = l
+}
+
+func GetLogger() Logger {
+	loggerMu.Lock()
+	defer loggerMu.Unlock()
+
+	if logger == nil {
+		logger = buildDefaultLogger()
+	}
+
+	return logger
+}
+
+type defaultLogger struct {
+	*logrus.Entry
+}
+
+func buildDefaultLogger() Logger {
+	l := &logrus.Logger{
+		Formatter: &logrus.TextFormatter{DisableTimestamp: true},
+		Level:     logrus.InfoLevel,
+		Out:       os.Stderr,
+		Hooks:     make(logrus.LevelHooks),
+	}
+
+	return &defaultLogger{Entry: l.WithFields(map[string]interface{}{})}
+}
+
+func (d *defaultLogger) ChildLogger(ff map[string]interface{}) Logger {
+	nl := &defaultLogger{d.Entry.WithFields(ff)}
+	return nl
 }


### PR DESCRIPTION
- removed logxi, fmt.PrintX, log.X, change to logrus like logging interface
- settable logger, logrus is the default
- don't exit hci.sktProcessLoop on event handling error