### PR TITLE
fix: better handling for encryption change and key refresh

### DIFF
--- a/error.go
+++ b/error.go
@@ -12,6 +12,9 @@ var ErrEIRPacketTooLong = errors.New("max packet length is 31")
 // ErrNotImplemented means the functionality is not implemented.
 var ErrNotImplemented = errors.New("not implemented")
 
+// ErrEncryptionAlreadyEnabled means that encryption is enabled and shouldn't be enabled again
+var ErrEncryptionAlreadyEnabled = errors.New("encryption already enabled")
+
 // ATTError is the error code of Attribute Protocol [Vol 3, Part F, 3.4.1.1].
 type ATTError byte
 

--- a/linux/hci/conn.go
+++ b/linux/hci/conn.go
@@ -433,10 +433,9 @@ func (c *Conn) handleEncryptionChanged(status uint8, enabled uint8) {
 		}
 	}
 
-	encEnabled := enabled == 0x01
-	c.encryptionEnabled = encEnabled
+	c.encryptionEnabled = enabled == 0x01
 
-	info := ble.EncryptionChangedInfo{Status: int(status), Err: err, Enabled: encEnabled}
+	info := ble.EncryptionChangedInfo{Status: int(status), Err: err, Enabled: c.encryptionEnabled}
 	if c.encChanged != nil {
 		select {
 		case c.encChanged <- info:

--- a/linux/hci/conn.go
+++ b/linux/hci/conn.go
@@ -65,6 +65,10 @@ type Conn struct {
 	// leFrame is set to be true when the LE Credit based flow control is used.
 	leFrame bool
 
+	// encryptionEnabled is set to true when an encryption change event arrives
+	// with a success status
+	encryptionEnabled bool
+
 	smp        SmpManager
 	encChanged chan ble.EncryptionChangedInfo
 	ble.Logger
@@ -140,6 +144,9 @@ func (c *Conn) Pair(authData ble.AuthData, to time.Duration) error {
 }
 
 func (c *Conn) StartEncryption(ch chan ble.EncryptionChangedInfo) error {
+	if c.encryptionEnabled {
+		return ble.ErrEncryptionAlreadyEnabled
+	}
 	c.encChanged = ch
 	err := c.smp.StartEncryption()
 	if err != nil {
@@ -426,16 +433,44 @@ func (c *Conn) handleEncryptionChanged(status uint8, enabled uint8) {
 		}
 	}
 
-	info := ble.EncryptionChangedInfo{Status: int(status), Err: err, Enabled: enabled == 0x01}
+	encEnabled := enabled == 0x01
+	c.encryptionEnabled = encEnabled
+
+	info := ble.EncryptionChangedInfo{Status: int(status), Err: err, Enabled: encEnabled}
 	if c.encChanged != nil {
 		select {
 		case c.encChanged <- info:
 			return
 		default:
-			c.Errorf("encryptionChanged: failed to send encryption changed status to channel: %v", info)
+			c.Errorf("encryptionChanged: failed to send encryption update to channel: %v", info)
 		}
 	} else {
-		c.Infof("encryptionChanged: status %v, err %v", status, err)
+		c.Infof("encryptionChanged: status %v", status)
+	}
+}
+
+func (c *Conn) handleEncryptionKeyRefreshComplete(status uint8) {
+	var err error
+	if status != 0x00 {
+		cmdErr := ErrCommand(status)
+		err = fmt.Errorf(errCmd[cmdErr])
+		if de := c.smp.DeleteBondInfo(); de != nil {
+			c.Errorf("encryptionChanged: failed to delete bond info: %v", err)
+		}
+	}
+
+	c.encryptionEnabled = true
+
+	info := ble.EncryptionChangedInfo{Status: int(status), Err: err, Enabled: true}
+	if c.encChanged != nil {
+		select {
+		case c.encChanged <- info:
+			return
+		default:
+			c.Errorf("encryptionKeyRefreshComplete: failed to send encryption update to channel: %v", info)
+		}
+	} else {
+		c.Infof("encryptionKeyRefreshComplete: status %v", status)
 	}
 }
 

--- a/linux/hci/hci.go
+++ b/linux/hci/hci.go
@@ -155,7 +155,7 @@ func (h *HCI) Init() error {
 	// evt.ReadRemoteVersionInformationCompleteCode: todo),
 	// evt.HardwareErrorCode:                        todo),
 	// evt.DataBufferOverflowCode:                   todo),
-	h.subh[evt.EncryptionKeyRefreshCompleteCode] = h.handleEncryptionKeyRefreshComplete,
+	h.subh[evt.EncryptionKeyRefreshCompleteCode] = h.handleEncryptionKeyRefreshComplete
 	// evt.AuthenticatedPayloadTimeoutExpiredCode:   todo),
 	// evt.LEReadRemoteUsedFeaturesCompleteSubCode:   todo),
 

--- a/linux/hci/smp/handler.go
+++ b/linux/hci/smp/handler.go
@@ -49,7 +49,7 @@ func smpOnPairingResponse(t *transport, in pdu) ([]byte, error) {
 	if !ok {
 		return nil, fmt.Errorf("invalid pairing type %v", t.pairing.pairingType)
 	}
-	t.Debugf("smpOnPairingResponse: detected pairing type '%v'", pts)
+	t.Infof("smpOnPairingResponse: detected pairing type '%v'", pts)
 
 	if t.pairing.pairingType == Oob &&
 		len(t.pairing.authData.OOBData) == 0 {
@@ -149,7 +149,13 @@ func onLegacyRandom(t *transport) ([]byte, error) {
 	rRand := t.pairing.remoteRandom
 
 	//calculate STK
-	k := getLegacyParingTK(t.pairing.authData.Passkey)
+	var k []byte
+	if t.pairing.pairingType == Passkey {
+		k = getLegacyParingTK(t.pairing.authData.Passkey)
+	} else {
+		k = getLegacyParingTK(0)
+	}
+
 	stk, err := smpS1(k, rRand, lRand)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
* Use a boolean to denote when encryption has been enabled
* This allows for us to return an error for a pairing or encryption request if it has already been enabled due to an asynchronous request from the peripheral
* Fix use of Passkey data from the auth struct when Passkey is not required