### PR TITLE
Drop spurious input channel closed error message

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -46,6 +46,8 @@ type Conn interface {
 	// Disconnected returns a receiving channel, which is closed when the connection disconnects.
 	Disconnected() <-chan struct{}
 
+	Closed() <-chan struct{}
+
 	Pair(AuthData, time.Duration) error
 
 	StartEncryption(change chan EncryptionChangedInfo) error

--- a/conn.go
+++ b/conn.go
@@ -46,8 +46,6 @@ type Conn interface {
 	// Disconnected returns a receiving channel, which is closed when the connection disconnects.
 	Disconnected() <-chan struct{}
 
-	Closed() <-chan struct{}
-
 	Pair(AuthData, time.Duration) error
 
 	StartEncryption(change chan EncryptionChangedInfo) error

--- a/linux/att/client.go
+++ b/linux/att/client.go
@@ -634,6 +634,9 @@ func (c *Client) Loop() {
 		case <-c.connClosed:
 			c.Debug("exited client async loop: conn closed")
 			return
+		case <-c.l2c.Closed():
+			c.Debug("exited client async loop: conn closed")
+			return
 		default:
 			if c.l2c == nil {
 				c.Debug("exited client loop: l2c nil")

--- a/linux/att/client.go
+++ b/linux/att/client.go
@@ -2,11 +2,11 @@ package att
 
 import (
 	"encoding/binary"
+	"errors"
 	"fmt"
-	"strings"
+	"io"
 	"time"
 
-	"github.com/pkg/errors"
 	"github.com/rigado/ble"
 )
 
@@ -513,7 +513,7 @@ func (c *Client) sendCmd(b []byte) error {
 func (c *Client) sendReq(b []byte) (rsp []byte, err error) {
 	c.Debugf("client: req % X", b)
 	if _, err := c.l2c.Write(b); err != nil {
-		return nil, errors.Wrap(err, "send ATT request failed")
+		return nil, fmt.Errorf("send ATT request failed: %w", err)
 	}
 	for {
 		select {
@@ -529,12 +529,12 @@ func (c *Client) sendReq(b []byte) (rsp []byte, err error) {
 			c.Debugf("client: rsp % X", b)
 			_, err := c.l2c.Write(errRsp)
 			if err != nil {
-				return nil, errors.Wrap(err, "unexpected ATT response received")
+				return nil, fmt.Errorf("unexpected ATT response received: %w", err)
 			}
 		case err := <-c.chErr:
-			return nil, errors.Wrap(err, "ATT request failed")
+			return nil, fmt.Errorf("ATT request failed: %w", err)
 		case <-time.After(2 * time.Second):
-			return nil, errors.Wrap(ErrSeqProtoTimeout, "ATT request timeout")
+			return nil, fmt.Errorf("ATT request timeout: %w", ErrSeqProtoTimeout)
 		}
 	}
 
@@ -548,7 +548,7 @@ func (c *Client) sendResp(rsp []byte) error {
 		return fmt.Errorf("ble conn was nil")
 	}
 	if _, err := c.l2c.Write(rsp); err != nil {
-		return errors.Wrap(err, "send ATT request failed")
+		return fmt.Errorf("send ATT request failed: %w", err)
 	}
 
 	return nil
@@ -640,7 +640,7 @@ func (c *Client) Loop() {
 				c.Debug("exited client loop: l2c nil")
 				return
 			} else if err != nil {
-				if strings.Contains(err.Error(), "input channel closed") {
+				if errors.Is(err, io.ErrClosedPipe) {
 					c.Debugf("input channel closed while reading due to disconnection or connection failure")
 					c.chErr <- fmt.Errorf("disconnected")
 				} else {

--- a/linux/att/client.go
+++ b/linux/att/client.go
@@ -642,6 +642,7 @@ func (c *Client) Loop() {
 			} else if err != nil {
 				if strings.Contains(err.Error(), "input channel closed") {
 					c.Debugf("input channel closed while reading due to disconnection or connection failure")
+					c.chErr <- fmt.Errorf("disconnected")
 				} else {
 					c.Errorf("client: read %v", err)
 

--- a/linux/hci/conn.go
+++ b/linux/hci/conn.go
@@ -160,7 +160,7 @@ func (c *Conn) StartEncryption(ch chan ble.EncryptionChangedInfo) error {
 func (c *Conn) Read(sdu []byte) (n int, err error) {
 	p, ok := <-c.chInPDU
 	if !ok {
-		return 0, errors.Wrap(io.ErrClosedPipe, "input channel closed")
+		return 0, fmt.Errorf("input channel closed: %w", io.ErrClosedPipe)
 	}
 	if len(p) == 0 {
 		return 0, errors.Wrap(io.ErrUnexpectedEOF, "received empty packet")

--- a/linux/hci/conn.go
+++ b/linux/hci/conn.go
@@ -129,6 +129,10 @@ func newConn(h *HCI, param evt.LEConnectionComplete, mac string) *Conn {
 	return c
 }
 
+func (c *Conn) Closed() <-chan struct{} {
+	return c.chDone
+}
+
 // Context returns the context that is used by this Conn.
 func (c *Conn) Context() context.Context {
 	return c.ctx

--- a/linux/hci/conn.go
+++ b/linux/hci/conn.go
@@ -129,10 +129,6 @@ func newConn(h *HCI, param evt.LEConnectionComplete, mac string) *Conn {
 	return c
 }
 
-func (c *Conn) Closed() <-chan struct{} {
-	return c.chDone
-}
-
 // Context returns the context that is used by this Conn.
 func (c *Conn) Context() context.Context {
 	return c.ctx


### PR DESCRIPTION
When the read function on an HCI connection returns due to the channel being closed, the library will no longer emit an error message. This is always due to a disconnect either planned or not and is essentially spurious. This PR removes that behavior but allows for other error messages to come through.