### PR TITLE
Set suggested max TX data length

### DIFF
--- a/examples/basic/advertiser/main.go
+++ b/examples/basic/advertiser/main.go
@@ -4,23 +4,26 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"github.com/rigado/ble/linux"
 	"log"
 	"time"
 
-	"github.com/rigado/ble"
-	"github.com/rigado/ble/examples/lib/dev"
 	"github.com/pkg/errors"
+	"github.com/rigado/ble"
 )
 
 var (
 	device = flag.String("device", "default", "implementation of ble")
 	du     = flag.Duration("du", 5*time.Second, "advertising duration, 0 for indefinitely")
+	name   = flag.String("name", "Cascade", "name of the peripheral device")
 )
 
 func main() {
 	flag.Parse()
 
-	d, err := dev.NewDevice("default")
+	opt := ble.OptTransportHCISocket(0)
+
+	d, err := linux.NewDeviceWithNameAndHandler("", nil, opt)
 	if err != nil {
 		log.Fatalf("can't new device : %s", err)
 	}
@@ -29,7 +32,7 @@ func main() {
 	// Advertise for specified durantion, or until interrupted by user.
 	fmt.Printf("Advertising for %s...\n", *du)
 	ctx := ble.WithSigHandler(context.WithTimeout(context.Background(), *du))
-	chkErr(ble.AdvertiseNameAndServices(ctx, "Gopher"))
+	chkErr(ble.AdvertiseNameAndServices(ctx, *name, ble.BatteryUUID, ble.DeviceInfoUUID))
 }
 
 func chkErr(err error) {

--- a/linux/adv/packet.go
+++ b/linux/adv/packet.go
@@ -2,8 +2,9 @@ package adv
 
 import (
 	"encoding/binary"
+	"fmt"
 
-	"github.com/pkg/errors"
+	"errors"
 	"github.com/rigado/ble"
 	"github.com/rigado/ble/parser"
 )
@@ -68,7 +69,12 @@ func NewRawPacket(bytes ...[]byte) (*Packet, error) {
 
 	//decode the bytes
 	m, err := parser.Parse(b)
-	err = errors.Wrapf(err, "pdu decode")
+	if !errors.Is(err, parser.EmptyOrNilPdu) {
+		err = fmt.Errorf("pdu decode: %w", err)
+	} else {
+		err = nil
+	}
+
 	switch {
 	case err == nil:
 		// ok

--- a/linux/adv/packet.go
+++ b/linux/adv/packet.go
@@ -69,10 +69,12 @@ func NewRawPacket(bytes ...[]byte) (*Packet, error) {
 
 	//decode the bytes
 	m, err := parser.Parse(b)
-	if !errors.Is(err, parser.EmptyOrNilPdu) {
-		err = fmt.Errorf("pdu decode: %w", err)
-	} else {
-		err = nil
+	if err != nil {
+		if !errors.Is(err, parser.EmptyOrNilPdu) {
+			err = fmt.Errorf("pdu decode: %w", err)
+		} else {
+			err = nil
+		}
 	}
 
 	switch {

--- a/linux/att/client.go
+++ b/linux/att/client.go
@@ -528,7 +528,7 @@ func (c *Client) sendReq(b []byte) (rsp []byte, err error) {
 			// returns an ErrReqNotSupp response, and continue to wait
 			// the response to our request.
 			errRsp := newErrorResponse(rsp[0], 0x0000, ble.ErrReqNotSupp)
-			c.Debugf("rsp: % X", b)
+			c.Debugf("rsp: %x", b)
 			_, err := c.l2c.Write(errRsp)
 			if err != nil {
 				return nil, fmt.Errorf("unexpected ATT response received: %w", err)
@@ -659,7 +659,7 @@ func (c *Client) Loop() {
 
 		b := make([]byte, n)
 		copy(b, c.rxBuf)
-		c.Debugf("rx: %v", hex.EncodeToString(b))
+		c.Debugf("rx: %x", b)
 
 		//all incoming requests are even numbered
 		//which means the last bit should be 0

--- a/linux/att/client.go
+++ b/linux/att/client.go
@@ -2,7 +2,6 @@ package att
 
 import (
 	"encoding/binary"
-	"encoding/hex"
 	"errors"
 
 	"fmt"
@@ -513,7 +512,7 @@ func (c *Client) sendCmd(b []byte) error {
 }
 
 func (c *Client) sendReq(b []byte) (rsp []byte, err error) {
-	c.Debugf("req: %v", hex.EncodeToString(b))
+	c.Debugf("req: %x", b)
 	if _, err := c.l2c.Write(b); err != nil {
 		return nil, fmt.Errorf("send ATT request failed: %w", err)
 	}
@@ -680,7 +679,7 @@ func (c *Client) Loop() {
 		}
 
 		if (b[0] != HandleValueNotificationCode) && (b[0] != HandleValueIndicationCode) {
-			c.Debugf("a rx: %v", hex.EncodeToString(c.rxBuf[:n]))
+			c.Debugf("a rx: %x", c.rxBuf[:n])
 			select {
 			case <-c.done:
 				c.Info("exited client loop: closed after rsp rx")
@@ -694,7 +693,7 @@ func (c *Client) Loop() {
 		}
 
 		// Deliver the full request to upper layer.
-		c.Debugf("notif: %v", hex.EncodeToString(b))
+		c.Debugf("notif: %x", b)
 		select {
 		case <-c.done:
 			c.Info("exited async loop: closed after rx")

--- a/linux/gatt/client.go
+++ b/linux/gatt/client.go
@@ -42,7 +42,7 @@ type sub struct {
 
 // NewClient returns a GATT Client.
 func NewClient(conn ble.Conn, cache ble.GattCache, done chan bool, l ble.Logger) (*Client, error) {
-	cl := l.ChildLogger(map[string]interface{}{"client": hex.EncodeToString(conn.RemoteAddr().Bytes())})
+	cl := l.ChildLogger(map[string]interface{}{"gatt": hex.EncodeToString(conn.RemoteAddr().Bytes())})
 	p := &Client{
 		subs:   make(map[uint16]*sub),
 		conn:   conn,

--- a/linux/gatt/client.go
+++ b/linux/gatt/client.go
@@ -456,7 +456,12 @@ func (p *Client) HandleNotification(req []byte) {
 	case sub.nHandler != nil:
 		sub.nHandler(sub.id, nd)
 	default:
-		p.Warnf("no handler, dropping data vh 0x%x, indication %v, id %v, %x", vh, indication, sub.id, nd)
+		select {
+		case <-p.Disconnected():
+			//ok
+		default:
+			p.Warnf("no handler, dropping data vh 0x%x, indication %v, id %v, %x", vh, indication, sub.id, nd)
+		}
 	}
 	sub.id++
 }

--- a/linux/gatt/client.go
+++ b/linux/gatt/client.go
@@ -457,7 +457,7 @@ func (p *Client) HandleNotification(req []byte) {
 		sub.nHandler(sub.id, nd)
 	default:
 		select {
-		case <-p.Disconnected():
+		case <-p.conn.Disconnected():
 			//ok
 		default:
 			p.Warnf("no handler, dropping data vh 0x%x, indication %v, id %v, %x", vh, indication, sub.id, nd)

--- a/linux/hci/cmd/cmd_gen.go
+++ b/linux/hci/cmd/cmd_gen.go
@@ -1560,3 +1560,34 @@ type LERemoteConnectionParameterRequestNegativeReplyRP struct {
 func (c *LERemoteConnectionParameterRequestNegativeReplyRP) Unmarshal(b []byte) error {
 	return unmarshal(c, b)
 }
+
+// LEWriteSuggestedDefaultDataLength implements LE Write Suggested Default Data Length (0x08|0x0024) [Vol 2, Part E, 7.8.35]
+type LEWriteSuggestedDefaultDataLength struct {
+	SuggestedMaxTxOctets uint16
+	SuggestedMaxTxTime   uint16
+}
+
+func (c *LEWriteSuggestedDefaultDataLength) String() string {
+	return "LE Write Suggested Default Data Length (0x08|0x0024)"
+}
+
+// OpCode returns the opcode of the command.
+func (c *LEWriteSuggestedDefaultDataLength) OpCode() int { return 0x08<<10 | 0x0024 }
+
+// Len returns the length of the command.
+func (c *LEWriteSuggestedDefaultDataLength) Len() int { return 4 }
+
+// Marshal serializes the command parameters into binary form.
+func (c *LEWriteSuggestedDefaultDataLength) Marshal(b []byte) error {
+	return marshal(c, b)
+}
+
+// LEWriteSuggestedDefaultDataLengthRP returns the return parameter of LE Write Suggested Default Data Length
+type LEWriteSuggestedDefaultDataLengthRP struct {
+	Status uint8
+}
+
+// Unmarshal de-serializes the binary data and stores the result in the receiver.
+func (c *LEWriteSuggestedDefaultDataLengthRP) Unmarshal(b []byte) error {
+	return unmarshal(c, b)
+}

--- a/linux/hci/conn.go
+++ b/linux/hci/conn.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/binary"
+	"encoding/hex"
 	"fmt"
 	"io"
 	"net"
@@ -352,6 +353,7 @@ func (c *Conn) writePDU(pdu []byte) (int, error) {
 		default:
 		}
 
+		c.Debugf("tx: %v", hex.EncodeToString(pkt.Bytes()))
 		if _, err := c.hci.skt.Write(pkt.Bytes()); err != nil {
 			return sent, err
 		}
@@ -377,7 +379,7 @@ func (c *Conn) recombine() error {
 	}
 
 	p := pdu(pkt.data())
-	c.Debugf("recombine: pdu in - % X", pkt.data())
+	c.Debugf("recombine: pdu in - %v", hex.EncodeToString(pkt.data()))
 	// Currently, check for LE-U only. For channels that we don't recognizes,
 	// re-combine them anyway, and discard them later when we dispatch the PDU
 	// according to CID.

--- a/linux/hci/conn.go
+++ b/linux/hci/conn.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/binary"
-	"encoding/hex"
 	"fmt"
 	"io"
 	"net"
@@ -353,7 +352,7 @@ func (c *Conn) writePDU(pdu []byte) (int, error) {
 		default:
 		}
 
-		c.Debugf("tx: %v", hex.EncodeToString(pkt.Bytes()))
+		c.Debugf("tx: %x", pkt.Bytes())
 		if _, err := c.hci.skt.Write(pkt.Bytes()); err != nil {
 			return sent, err
 		}
@@ -379,7 +378,7 @@ func (c *Conn) recombine() error {
 	}
 
 	p := pdu(pkt.data())
-	c.Debugf("recombine: pdu in - %v", hex.EncodeToString(pkt.data()))
+	c.Debugf("recombine: pdu in - %x", pkt.data())
 	// Currently, check for LE-U only. For channels that we don't recognizes,
 	// re-combine them anyway, and discard them later when we dispatch the PDU
 	// according to CID.

--- a/linux/hci/conn.go
+++ b/linux/hci/conn.go
@@ -152,7 +152,7 @@ func (c *Conn) StartEncryption(ch chan ble.EncryptionChangedInfo) error {
 				select {
 				case ch <- conn.encInfo:
 					//ok
-				default:
+				case <-time.After(1 * time.Second):
 					conn.Errorf("encryptionChanged: failed to send encryption update to channel: %v", conn.encInfo)
 				}
 			}(c, ch)

--- a/linux/hci/hci.go
+++ b/linux/hci/hci.go
@@ -931,7 +931,7 @@ func (h *HCI) handleEncryptionKeyRefreshComplete(b []byte) error {
 
 func (h *HCI) handleNumberOfCompletedPackets(b []byte) error {
 	e := evt.NumberOfCompletedPackets(b)
-	h.Debugf("numberOfCompletedPackets: % X", b)
+	h.Debugf("numberOfCompletedPackets: %v", hex.EncodeToString(b))
 	h.muConns.Lock()
 	defer h.muConns.Unlock()
 	for i := 0; i < int(e.NumberOfHandles()); i++ {

--- a/linux/hci/hci.go
+++ b/linux/hci/hci.go
@@ -302,6 +302,9 @@ func (h *HCI) init() error {
 	WriteLEHostSupportRP := cmd.WriteLEHostSupportRP{}
 	h.Send(&cmd.WriteLEHostSupport{LESupportedHost: 1, SimultaneousLEHost: 0}, &WriteLEHostSupportRP)
 
+	WriteDefaultDataLengthRP := cmd.LEWriteSuggestedDefaultDataLengthRP{}
+	h.Send(&cmd.LEWriteSuggestedDefaultDataLength{SuggestedMaxTxOctets: 251, SuggestedMaxTxTime: 2120}, &WriteDefaultDataLengthRP)
+
 	return h.err
 }
 

--- a/linux/hci/hci.go
+++ b/linux/hci/hci.go
@@ -400,6 +400,7 @@ func (h *HCI) send(c Command) ([]byte, error) {
 	h.sent[oc] = p //use oc here due to swap to 0xff for vendor events
 	h.muSent.Unlock()
 
+	h.Debugf("tx op: %v - %v", c.OpCode(), hex.EncodeToString(b))
 	if !h.isOpen() {
 		return nil, fmt.Errorf("hci closed")
 	} else if n, err := h.skt.Write(b[:4+c.Len()]); err != nil {
@@ -522,6 +523,7 @@ func (h *HCI) close(err error) error {
 
 func (h *HCI) handlePkt(b []byte) error {
 	// Strip the 1-byte HCI header and pass down the rest of the packet.
+	h.Debugf("hci rx: %v", hex.EncodeToString(b))
 	t, b := b[0], b[1:]
 	switch t {
 	case pktTypeACLData:

--- a/linux/hci/hci.go
+++ b/linux/hci/hci.go
@@ -523,10 +523,10 @@ func (h *HCI) close(err error) error {
 
 func (h *HCI) handlePkt(b []byte) error {
 	// Strip the 1-byte HCI header and pass down the rest of the packet.
-	h.Debugf("hci rx: %v", hex.EncodeToString(b))
 	t, b := b[0], b[1:]
 	switch t {
 	case pktTypeACLData:
+		h.Debugf("hci rx acl: %v", hex.EncodeToString(b))
 		return h.handleACL(b)
 	case pktTypeEvent:
 		return h.handleEvt(b)

--- a/linux/tools/codegen/cmd.json
+++ b/linux/tools/codegen/cmd.json
@@ -1241,6 +1241,29 @@
                         "Events": [
                                 "Command Complete"
                         ]
+                },
+                {
+                        "Name": "LE Write Suggested Default Data Length",
+                        "Spec": "Vol 2, Part E, 7.8.35",
+                        "OGF": "0x08",
+                        "OCF": "0x0024",
+                        "Len": 4,
+                        "Param": [
+                                {
+                                        "SuggestedMaxTxOctets": "uint16"
+                                },
+                                {
+                                        "SuggestedMaxTxTime": "uint16"
+                                }
+                        ],
+                        "Return": [
+                                {
+                                        "Status": "uint8"
+                                }
+                        ],
+                        "Events": [
+                                "Command Complete"
+                        ]
                 }
         ]
 }

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -3,9 +3,11 @@ package parser
 import (
 	"fmt"
 
-	"github.com/pkg/errors"
+	"errors"
 	"github.com/rigado/ble"
 )
+
+var EmptyOrNilPdu = errors.New("nil/empty pdu")
 
 // https://www.bluetooth.org/en-us/specification/assigned-numbers/generic-access-profile
 var types = struct {
@@ -207,7 +209,7 @@ func getArray(size int, bytes []byte) ([]ble.UUID, error) {
 
 func Parse(pdu []byte) (map[string]interface{}, error) {
 	if len(pdu) == 0 {
-		return nil, fmt.Errorf("nil/empty pdu")
+		return nil, EmptyOrNilPdu
 	}
 
 	m := make(map[string]interface{})
@@ -225,7 +227,7 @@ func Parse(pdu []byte) (map[string]interface{}, error) {
 
 		//do we have all the bytes for the payload?
 		if (i + length) >= len(pdu) {
-			return m, fmt.Errorf("buffer overflow: want %v, have %v, idx %v", (i + length), len(pdu), i)
+			return m, fmt.Errorf("buffer overflow: want %v, have %v, idx %v", i+length, len(pdu), i)
 		}
 
 		start := i + 2
@@ -245,7 +247,7 @@ func Parse(pdu []byte) (map[string]interface{}, error) {
 
 				//is this fatal?
 				if err != nil {
-					return m, errors.Wrapf(err, "adv type %v, idx %v", typ, i)
+					return m, fmt.Errorf("adv type %v, idx %v: %w", typ, i, err)
 				}
 
 				v, ok := m[dec.key].([]ble.UUID)


### PR DESCRIPTION
* Set the suggested max TX data length
* Some logging cleanup in the client
* Allow for timeout on encryption changed information
* Check for disconnection before posting warning about dropped notification
* Allow for an empty PDU on incoming advertisements
* Use %w for error wrapping instead of non-standard errors.Wrap function