### PR TITLE
Resolve blocking channel

### DIFF
--- a/gatt.go
+++ b/gatt.go
@@ -144,8 +144,17 @@ func Connect(ctx context.Context, f AdvFilter) (Client, error) {
 		}
 	}
 
-	cln, err := Dial(ctx, (<-ch).Addr())
-	return cln, errors.Wrap(err, "can't dial")
+	select {
+	case a, ok := <-ch:
+		if ok {
+			cln, err := Dial(ctx, a.Addr())
+			return cln, errors.Wrap(err, "can't dial")
+		} else {
+			return nil, errors.New("channel closed")
+		}
+	default:
+		return nil, errors.New("not found")
+	}
 }
 
 // A NotificationHandler handles notification or indication from a server.


### PR DESCRIPTION
@wimaha found a bug in glatt.go in Connect function. Orgininally in #go-ble/ble#112, but I'm not sure if that repository is really active. I have the same issue, but have switched to this repository some time ago.

Here's a short description of the bug:
When a device can't be found, normally ctx2 fires bevor ctx, so that the function Scan returns context deadline exceeded.

Sometimes (rarely but randomly) ctx fires and cancels ctx2 (see line 131). In this case Scan return with context canceled. This yields to the line 147 cln, err := Dial(ctx, (<-ch).Addr()) is executed and ist blocking, because of (<-ch).Addr().

For this case I propose a simple fix with this PR.

The issue occurs, if a specific BLE beacon that I'm looking for, can't be found. I'm using the ble package with a cmd tool from Teslamotors (https://github.com/teslamotors/vehicle-command/tree/main/cmd/tesla-control) to verify if my Tesla is at home. When the car is at home, everything works fine, but if the car is away then the tool hangs / does not return from time to time. I'm calling the tool from a script every minute and it may take some minutes or hours after the issue occurs.